### PR TITLE
Remove warning about deprecated spring-boot plugin from Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 apply plugin: 'java'
-apply plugin: 'spring-boot'
+apply plugin: 'org.springframework.boot'
 
 jar {
     baseName = 'zally'


### PR DESCRIPTION
Removes the following warning:

```bash
$ gradle
The plugin id 'spring-boot' is deprecated. Please use 'org.springframework.boot' instead.
:help
```