### PR TITLE
Add NoVersionInUriRule to Set of Rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ jdk:
   - oraclejdk8
 
 install: true
-script: gradle test
+script: gradle test --info

--- a/src/main/java/de/zalando/zally/rules/NoVersionInUriRule.java
+++ b/src/main/java/de/zalando/zally/rules/NoVersionInUriRule.java
@@ -1,0 +1,41 @@
+package de.zalando.zally.rules;
+
+import de.zalando.zally.Violation;
+import de.zalando.zally.ViolationType;
+import io.swagger.models.Swagger;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+public class NoVersionInUriRule implements Rule {
+
+    public final String LINK =
+            "https://zalando.github.io/restful-api-guidelines/compatibility/Compatibility.html" +
+            "#must-do-not-use-uri-versioning";
+    public final String PATTERN = "(.*)/v[0-9]+(.*)";
+
+    @Override
+    public List<Violation> validate(Swagger swagger) {
+        List<Violation> violations = new ArrayList<>();
+
+        String basePath = swagger.getBasePath();
+
+        Pattern pattern = Pattern.compile(PATTERN);
+
+        if (pattern.matcher(basePath).matches()) {
+            violations.add(
+                new Violation(
+                    "Do Not Use URI Versioning",
+                    "basePath attribute contains version number",
+                    ViolationType.MUST,
+                    LINK
+                )
+            );
+        }
+
+        return violations;
+    }
+}

--- a/src/test/java/de/zalando/zally/rules/NoVersionInUriRuleTest.java
+++ b/src/test/java/de/zalando/zally/rules/NoVersionInUriRuleTest.java
@@ -1,0 +1,57 @@
+package de.zalando.zally.rules;
+
+import de.zalando.zally.Violation;
+import de.zalando.zally.ViolationType;
+import io.swagger.models.Swagger;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class NoVersionInUriRuleTest {
+    private final NoVersionInUriRule rule = new NoVersionInUriRule();
+
+    private void assertViolationOccurs(String basePath) {
+        Swagger swagger = new Swagger();
+        swagger.basePath(basePath);
+
+        List<Violation> violations = rule.validate(swagger);
+        assertEquals(1, violations.size());
+
+        Violation violation = violations.get(0);
+        assertEquals("Do Not Use URI Versioning", violation.getTitle());
+        assertEquals("basePath attribute contains version number", violation.getDescription());
+        assertEquals(ViolationType.MUST, violation.getViolationType());
+        assertEquals(rule.LINK, violation.getRuleLink());
+    }
+
+    @Test
+    public void returnsViolationsWhenVersionIsInTheBeginingOfBasePath() {
+        assertViolationOccurs("/v1/tests");
+    }
+
+    @Test
+    public void returnsViolationsWhenVersionIsInTheMiddleOfBasePath() {
+        assertViolationOccurs("/api/v1/tests");
+    }
+
+    @Test
+    public void returnsViolationsWhenVersionIsInTheEndOfBasePath() {
+        assertViolationOccurs("/api/v1");
+    }
+
+    @Test
+    public void returnsViolationsWhenVersionIsBig() {
+        assertViolationOccurs("/v1024/tests");
+    }
+
+    @Test
+    public void returnsEmptyViolationListWhenNoVersionFoundInURL() {
+        Swagger swagger = new Swagger();
+        swagger.basePath("/violations/");
+
+        List<Violation> violations = rule.validate(swagger);
+        assertEquals(0, violations.size());
+    }
+}


### PR DESCRIPTION
Add the rule to validate:
https://zalando.github.io/restful-api-guidelines/compatibility/Compatibility.html#must-do-not-use-uri-versioning 