### PR TITLE
Handle empty basePath properly in NoVersionInUriRule

### DIFF
--- a/src/main/java/de/zalando/zally/rules/NoVersionInUriRule.java
+++ b/src/main/java/de/zalando/zally/rules/NoVersionInUriRule.java
@@ -25,7 +25,7 @@ public class NoVersionInUriRule implements Rule {
 
         Pattern pattern = Pattern.compile(PATTERN);
 
-        if (pattern.matcher(basePath).matches()) {
+        if (basePath != null && pattern.matcher(basePath).matches()) {
             violations.add(
                 new Violation(
                     "Do Not Use URI Versioning",

--- a/src/test/java/de/zalando/zally/rules/NoVersionInUriRuleTest.java
+++ b/src/test/java/de/zalando/zally/rules/NoVersionInUriRuleTest.java
@@ -26,6 +26,14 @@ public class NoVersionInUriRuleTest {
         assertEquals(rule.LINK, violation.getRuleLink());
     }
 
+    private void assertNoViolations(String basePath) {
+        Swagger swagger = new Swagger();
+        swagger.basePath(basePath);
+
+        List<Violation> violations = rule.validate(swagger);
+        assertEquals(0, violations.size());
+    }
+
     @Test
     public void returnsViolationsWhenVersionIsInTheBeginingOfBasePath() {
         assertViolationOccurs("/v1/tests");
@@ -48,10 +56,11 @@ public class NoVersionInUriRuleTest {
 
     @Test
     public void returnsEmptyViolationListWhenNoVersionFoundInURL() {
-        Swagger swagger = new Swagger();
-        swagger.basePath("/violations/");
+        assertNoViolations("/violations/");
+    }
 
-        List<Violation> violations = rule.validate(swagger);
-        assertEquals(0, violations.size());
+    @Test
+    public void returnsEmptyViolationListWhenBasePathIsNull() {
+        assertNoViolations(null);
     }
 }


### PR DESCRIPTION
Follow-up for #6 

Fixes the issue with empty `basePath`