### PR TITLE
Add SecureWithOAuth2Rule to the Rules Set

### DIFF
--- a/src/main/java/de/zalando/zally/rules/SecureWithOAuth2Rule.java
+++ b/src/main/java/de/zalando/zally/rules/SecureWithOAuth2Rule.java
@@ -1,0 +1,43 @@
+package de.zalando.zally.rules;
+
+import de.zalando.zally.Violation;
+import de.zalando.zally.ViolationType;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.SecuritySchemeDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class SecureWithOAuth2Rule implements Rule {
+    public final String LINK =
+            "https://zalando.github.io/restful-api-guidelines/security/Security.html" +
+            "#must-secure-endpoints-with-oauth-20";
+    public final String TITLE = "Secure Endpoints with OAuth 2.0";
+
+    @Override
+    public List<Violation> validate(Swagger swagger) {
+        List<Violation> violations = new ArrayList<>();
+        Map<String, SecuritySchemeDefinition> securityDefinitions = swagger.getSecurityDefinitions();
+
+        if (!hasAnyOauth2SecurityDefinition(securityDefinitions)) {
+            violations.add(
+                    new Violation(TITLE, "No OAuth2 security definitions found", ViolationType.MUST, LINK)
+            );
+        }
+
+        return violations;
+    }
+
+    private boolean hasAnyOauth2SecurityDefinition(Map<String, SecuritySchemeDefinition> securityDefinitions) {
+        if (securityDefinitions == null) {
+            return false;
+        }
+
+        return securityDefinitions
+                .values()
+                .stream()
+                .anyMatch(v -> v.getType().toLowerCase().equals("oauth2"));
+    }
+}

--- a/src/test/java/de/zalando/zally/rules/SecureWithOAuth2RuleTest.java
+++ b/src/test/java/de/zalando/zally/rules/SecureWithOAuth2RuleTest.java
@@ -1,0 +1,74 @@
+package de.zalando.zally.rules;
+
+import de.zalando.zally.Violation;
+import de.zalando.zally.ViolationType;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.ApiKeyAuthDefinition;
+import io.swagger.models.auth.BasicAuthDefinition;
+import io.swagger.models.auth.OAuth2Definition;
+import io.swagger.models.auth.SecuritySchemeDefinition;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class SecureWithOAuth2RuleTest {
+    private final SecureWithOAuth2Rule rule = new SecureWithOAuth2Rule();
+
+    private void assertViolationOccurs(Swagger swagger) {
+        List<Violation> violations = rule.validate(swagger);
+        assertEquals(1, violations.size());
+
+        Violation violation = violations.get(0);
+        assertEquals("Secure Endpoints with OAuth 2.0", violation.getTitle());
+        assertEquals("No OAuth2 security definitions found", violation.getDescription());
+        assertEquals(ViolationType.MUST, violation.getViolationType());
+        assertEquals(rule.LINK, violation.getRuleLink());
+    }
+
+    private void assertNoViolations(Swagger swagger) {
+        List<Violation> violations = rule.validate(swagger);
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void returnsViolationsWhenSecurityDefinitionsAreNotInitialized() {
+        Swagger swagger = new Swagger();
+        assertViolationOccurs(swagger);
+    }
+
+    @Test
+    public void returnsViolationsWhenNoSecurityDefinitionsAreSpecified() {
+        Swagger swagger = new Swagger();
+        swagger.setSecurityDefinitions(new HashMap<>());
+        assertViolationOccurs(swagger);
+    }
+
+    @Test
+    public void returnsViolationsWhenNoOAuth2SecurityDefinitionsAreSpecified() {
+        Map<String, SecuritySchemeDefinition> definitions = new HashMap<>();
+        definitions.put("Basic", new BasicAuthDefinition());
+        definitions.put("ApiKey", new ApiKeyAuthDefinition());
+
+        Swagger swagger = new Swagger();
+        swagger.setSecurityDefinitions(definitions);
+
+        assertViolationOccurs(swagger);
+    }
+
+    @Test
+    public void returnsNoViolationsWhenOAuth2SecurityDefinitionsIsSpecified() {
+        Map<String, SecuritySchemeDefinition> definitions = new HashMap<>();
+        definitions.put("Basic", new BasicAuthDefinition());
+        definitions.put("Oauth2", new OAuth2Definition());
+
+        Swagger swagger = new Swagger();
+        swagger.setSecurityDefinitions(definitions);
+
+        assertNoViolations(swagger);
+    }
+}


### PR DESCRIPTION
🔋 

One more rule:
https://zalando.github.io/restful-api-guidelines/security/Security.html#must-secure-endpoints-with-oauth-20
