### PR TITLE
CLI: Introduce gradle-one-jar Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .gradle/
 .idea/
+bin/
 build/
 gradle/
 .DS_Store

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -26,3 +26,12 @@ task zallyJar(type: OneJar) {
     mainClass = 'de.zalando.zally.cli.Main'
     archiveName = 'zally.jar'
 }
+
+task bin {
+    dependsOn zallyJar
+    copy {
+        from 'build/libs'
+        into 'bin'
+        include '**/zally.jar'
+    }
+}

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'gradle-one-jar'
 
 repositories {
     mavenCentral()
@@ -8,4 +9,20 @@ dependencies {
     compile 'com.github.ryenus:rop:1.1.1'
 
     testCompile 'junit:junit:4.12'
+}
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.github.rholder:gradle-one-jar:1.0.4'
+    }
+}
+
+task zallyJar(type: OneJar) {
+    dependsOn build
+    mainClass = 'de.zalando.zally.cli.Main'
+    archiveName = 'zally.jar'
 }


### PR DESCRIPTION
🔋 

## How to test:
1. Run `gradle bin`
2. Observe a "fat" zally.jar file in `bin` folder