### PR TITLE
Hypen pascal case http headers

### DIFF
--- a/src/main/java/de/zalando/zally/rules/HttpHeadersRule.java
+++ b/src/main/java/de/zalando/zally/rules/HttpHeadersRule.java
@@ -1,0 +1,75 @@
+package de.zalando.zally.rules;
+
+import de.zalando.zally.Violation;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.Parameter;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public abstract class HttpHeadersRule implements Rule {
+
+    public static final Set<String> PARAMETER_NAMES_WHITELIST = new HashSet<>(Arrays.asList("ETag", "TSV", "TE",
+            "Content-MD5", "DNT", "X-ATT-DeviceId", "X-UIDH", "X-Request-ID", "X-Correlation-ID", "WWW-Authenticate",
+            "X-XSS-Protection"));
+
+    abstract Violation createViolation(String header, Optional<String> path);
+
+    abstract boolean isViolation(String header);
+
+    @Override
+    public List<Violation> validate(Swagger swagger) {
+        List<Violation> res = new ArrayList<>();
+        if (swagger.getParameters() != null) {
+            res.addAll(validateParameters(swagger.getParameters().values(), Optional.empty()));
+        }
+        if (swagger.getPaths() != null) {
+            for (Map.Entry<String, Path> pathEntry: swagger.getPaths().entrySet()) {
+                Optional<String> pathName = Optional.of(pathEntry.getKey());
+                res.addAll(validateParameters(pathEntry.getValue().getParameters(), pathName));
+                for (Operation operation : pathEntry.getValue().getOperations()) {
+                    res.addAll(validateParameters(operation.getParameters(), pathName));
+                    res.addAll(validateHeaders(getResponseHeaders(operation.getResponses()), pathName));
+                }
+            }
+        }
+        res.addAll(validateHeaders(getResponseHeaders(swagger.getResponses()), Optional.empty()));
+        return res;
+    }
+
+    private List<Violation> validateParameters(Collection<Parameter> parameters, Optional<String> path) {
+        if (parameters == null) {
+            return Collections.emptyList();
+        }
+        return validateHeaders(parameters
+                .stream()
+                .filter(p -> p.getIn().equals("header"))
+                .map(Parameter::getName)
+                .collect(Collectors.toList()), path);
+    }
+
+    private List<Violation> validateHeaders(Collection<String> headers, Optional<String> path) {
+        if (headers == null) {
+            return Collections.emptyList();
+        }
+        return headers
+                .stream()
+                .filter(p -> !PARAMETER_NAMES_WHITELIST.contains(p) && isViolation(p))
+                .map(p -> this.createViolation(p, path))
+                .collect(Collectors.toList());
+    }
+
+    private Set<String> getResponseHeaders(Map<String, Response> responses) {
+        if (responses != null) {
+            for (Response response : responses.values()) {
+                if (response.getHeaders() != null) {
+                    return response.getHeaders().keySet();
+                }
+            }
+        }
+        return Collections.emptySet();
+    }
+}

--- a/src/main/java/de/zalando/zally/rules/HttpHeadersRule.java
+++ b/src/main/java/de/zalando/zally/rules/HttpHeadersRule.java
@@ -14,7 +14,7 @@ public abstract class HttpHeadersRule implements Rule {
 
     public static final Set<String> PARAMETER_NAMES_WHITELIST = new HashSet<>(Arrays.asList("ETag", "TSV", "TE",
             "Content-MD5", "DNT", "X-ATT-DeviceId", "X-UIDH", "X-Request-ID", "X-Correlation-ID", "WWW-Authenticate",
-            "X-XSS-Protection"));
+            "X-XSS-Protection", "X-Flow-ID", "X-UID", "X-Tenant-ID", "X-Device-OS"));
 
     abstract Violation createViolation(String header, Optional<String> path);
 

--- a/src/main/java/de/zalando/zally/rules/HyphenateHttpHeadersRule.java
+++ b/src/main/java/de/zalando/zally/rules/HyphenateHttpHeadersRule.java
@@ -1,5 +1,6 @@
 package de.zalando.zally.rules;
 
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import de.zalando.zally.Violation;
 import de.zalando.zally.ViolationType;
 import de.zalando.zally.utils.PatternUtil;
@@ -12,73 +13,23 @@ import io.swagger.models.parameters.Parameter;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class HyphenateHttpHeadersRule implements Rule {
+public class HyphenateHttpHeadersRule extends HttpHeadersRule {
 
-    public static final String RULE_NAME = "Must: Use Hyphenated HTTP Headers";
-    public static final String RULE_URL = "http://zalando.github.io/restful-api-guidelines/naming/Naming.html" +
+    static final String RULE_NAME = "Must: Use Hyphenated HTTP Headers";
+    static final String RULE_URL = "http://zalando.github.io/restful-api-guidelines/naming/Naming.html" +
             "#must-use-hyphenated-http-headers";
-    public static final String DESC_PATTERN = "Header name '%s' is not hyphenated";
-    public static final Set<String> PARAMETER_NAMES_WHITELIST = new HashSet<>(Arrays.asList("ETag", "TSV", "TE",
-            "Content-MD5", "DNT", "X-ATT-DeviceId", "X-UIDH", "X-Request-ID", "X-Correlation-ID", "WWW-Authenticate",
-            "X-XSS-Protection"));
+    static final String DESC_PATTERN = "Header name '%s' is not hyphenated";
 
     @Override
-    public List<Violation> validate(Swagger swagger) {
-        List<Violation> res = new ArrayList<>();
-        if (swagger.getParameters() != null) {
-            res.addAll(validateParameters(swagger.getParameters().values(), Optional.empty()));
-        }
-        if (swagger.getPaths() != null) {
-            for (Map.Entry<String, Path> pathEntry: swagger.getPaths().entrySet()) {
-                Optional<String> pathName = Optional.of(pathEntry.getKey());
-                res.addAll(validateParameters(pathEntry.getValue().getParameters(), pathName));
-                for (Operation operation : pathEntry.getValue().getOperations()) {
-                    res.addAll(validateParameters(operation.getParameters(), pathName));
-                    res.addAll(validateHeaders(getResponseHeaders(operation.getResponses()), pathName));
-                }
-            }
-        }
-        res.addAll(validateHeaders(getResponseHeaders(swagger.getResponses()), Optional.empty()));
-        return res;
-    }
-
-    private List<Violation> validateParameters(Collection<Parameter> parameters, Optional<String> path) {
-        if (parameters == null) {
-            return Collections.emptyList();
-        }
-        return validateHeaders(parameters
-                .stream()
-                .filter(p -> p.getIn().equals("header"))
-                .map(Parameter::getName)
-                .collect(Collectors.toList()), path);
-    }
-
-    private List<Violation> validateHeaders(Collection<String> headers, Optional<String> path) {
-        if (headers == null) {
-            return Collections.emptyList();
-        }
-        return headers
-                .stream()
-                .filter(p -> !PARAMETER_NAMES_WHITELIST.contains(p) && !PatternUtil.isHyphenated(p))
-                .map(p -> this.createViolation(p, path))
-                .collect(Collectors.toList());
-    }
-
-    private Violation createViolation(String header, Optional<String> path) {
+    Violation createViolation(String header, Optional<String> path) {
         if (path.isPresent()) {
             return new Violation(RULE_NAME, String.format(DESC_PATTERN, header), ViolationType.MUST, RULE_URL, path.get());
         }
         return new Violation(RULE_NAME, String.format(DESC_PATTERN, header), ViolationType.MUST, RULE_URL);
     }
 
-    private Set<String> getResponseHeaders(Map<String, Response> responses) {
-        if (responses != null) {
-            for (Response response : responses.values()) {
-                if (response.getHeaders() != null) {
-                    return response.getHeaders().keySet();
-                }
-            }
-        }
-        return Collections.emptySet();
+    @Override
+    boolean isViolation(String header) {
+        return !PatternUtil.isHyphenated(header);
     }
 }

--- a/src/main/java/de/zalando/zally/rules/PascalCaseHttpHeadersRule.java
+++ b/src/main/java/de/zalando/zally/rules/PascalCaseHttpHeadersRule.java
@@ -1,0 +1,27 @@
+package de.zalando.zally.rules;
+
+import de.zalando.zally.Violation;
+import de.zalando.zally.ViolationType;
+import de.zalando.zally.utils.PatternUtil;
+
+import java.util.*;
+
+public class PascalCaseHttpHeadersRule extends HttpHeadersRule {
+    static final String RULE_NAME = "Prefer Hyphenated-Pascal-Case for HTTP header fields";
+    static final String RULE_URL = "http://zalando.github.io/restful-api-guidelines/naming/Naming.html" +
+            "#should-prefer-hyphenatedpascalcase-for-http-header-fields";
+    static final String DESCRIPTION = "Header name '%s' is not Hyphenated-Pascal-Case";
+
+    @Override
+    Violation createViolation(String header, Optional<String> path) {
+        if (path.isPresent()) {
+            return new Violation(RULE_NAME, String.format(DESCRIPTION, header), ViolationType.SHOULD, RULE_URL, path.get());
+        }
+        return new Violation(RULE_NAME, String.format(DESCRIPTION, header), ViolationType.SHOULD, RULE_URL);
+    }
+
+    @Override
+    boolean isViolation(String header) {
+        return !PatternUtil.isHyphenatedPascalCase(header);
+    }
+}

--- a/src/main/java/de/zalando/zally/rules/RulesValidatorConfiguration.java
+++ b/src/main/java/de/zalando/zally/rules/RulesValidatorConfiguration.java
@@ -27,6 +27,7 @@ public class RulesValidatorConfiguration {
                 new HyphenateHttpHeadersRule(),
                 new MediaTypesRule(),
                 new LimitNumberOfSubresourcesRule(),
+                new PascalCaseHttpHeadersRule(),
                 new VersionInInfoSectionRule(),
                 new NestedPathsCouldBeRootPathsRule(),
                 new EverySecondPathLevelParameterRule(),

--- a/src/main/java/de/zalando/zally/utils/PatternUtil.java
+++ b/src/main/java/de/zalando/zally/utils/PatternUtil.java
@@ -11,7 +11,7 @@ public class PatternUtil {
     private static final String CAMEL_CASE_PATTERN = "^[a-z]+(?:[A-Z][a-z]+)*$";
     private static final String PASCAL_CASE_PATTERN = "^[A-Z][a-z]+(?:[A-Z][a-z]+)*$";
     private static final String HYPHENATED_CAMEL_CASE_PATTERN = "^[a-z]+(?:-[A-Z][a-z]+)*$";
-    private static final String HYPHENATED_PASCAL_CASE_PATTERN = "^[A-Z][a-z]+(?:-[A-Z][a-z]+)*$";
+    private static final String HYPHENATED_PASCAL_CASE_PATTERN = "^[A-Z][a-z]*(?:-[A-Z][a-z]+)*$";
     private static final String SNAKE_CASE_PATTERN = "^[a-z]+(?:_[a-z0-9]+)*$";
     private static final String KEBAB_CASE_PATTERN = "^[a-z]+(?:-[a-z]+)*$";
     private static final String VERSION_IN_URL_PATTERN = "(.*)/v[0-9]+(.*)";

--- a/src/test/java/de/zalando/zally/rules/PascalCaseHttpHeadersRuleTest.java
+++ b/src/test/java/de/zalando/zally/rules/PascalCaseHttpHeadersRuleTest.java
@@ -1,0 +1,78 @@
+package de.zalando.zally.rules;
+
+import de.zalando.zally.Violation;
+import de.zalando.zally.ViolationType;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.HeaderParameter;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.parser.SwaggerParser;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static de.zalando.zally.rules.PascalCaseHttpHeadersRule.RULE_NAME;
+import static de.zalando.zally.rules.PascalCaseHttpHeadersRule.RULE_URL;
+import static de.zalando.zally.rules.PascalCaseHttpHeadersRule.DESCRIPTION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PascalCaseHttpHeadersRuleTest {
+
+    @Test
+    public void simplePositiveCase() {
+        Swagger swagger = new Swagger();
+        HashMap<String, Parameter> parameters = new HashMap<>();
+        HeaderParameter parameter = new HeaderParameter();
+        parameter.setName("Right-Name");
+        parameters.put(parameter.getName(), parameter);
+        swagger.setParameters(parameters);
+        assertThat(new PascalCaseHttpHeadersRule().validate(swagger)).isEmpty();
+    }
+
+    @Test
+    public void simpleNegativeCase() {
+        Swagger swagger = new Swagger();
+        String badHeader = "kebap-case-name";
+        HashMap<String, Parameter> parameters = new HashMap<>();
+        HeaderParameter parameter = new HeaderParameter();
+        parameter.setName(badHeader);
+        parameters.put(parameter.getName(), parameter);
+        swagger.setParameters(parameters);
+        List<Violation> result = new PascalCaseHttpHeadersRule().validate(swagger);
+        assertThat(result).hasSameElementsAs(Collections.singletonList(
+                new Violation(RULE_NAME, String.format(DESCRIPTION, badHeader), ViolationType.SHOULD, RULE_URL))
+        );
+    }
+
+    @Test
+    public void mustAcceptETag() {
+        Swagger swagger = new Swagger();
+        HashMap<String, Parameter> parameters = new HashMap<>();
+        HeaderParameter parameter = new HeaderParameter();
+        parameter.setName("ETag");
+        parameters.put(parameter.getName(), parameter);
+        swagger.setParameters(parameters);
+        assertThat(new PascalCaseHttpHeadersRule().validate(swagger)).isEmpty();
+    }
+
+    @Test
+    public void emptySwaggerShouldPass() {
+        Swagger swagger = new Swagger();
+        swagger.setParameters(new HashMap<>());
+        assertThat(new PascalCaseHttpHeadersRule().validate(swagger)).isEmpty();
+    }
+
+    @Test
+    public void positiveCaseSpp() {
+        Swagger swagger = new SwaggerParser().read("api_spp.json");
+        assertThat(new PascalCaseHttpHeadersRule().validate(swagger)).isEmpty();
+    }
+
+    @Test
+    public void positiveCaseTinbox() {
+        Swagger swagger = new SwaggerParser().read("api_tinbox.yaml");
+        assertThat(new PascalCaseHttpHeadersRule().validate(swagger)).isEmpty();
+    }
+}
+

--- a/src/test/java/de/zalando/zally/rules/PascalCaseHttpHeadersRuleTest.java
+++ b/src/test/java/de/zalando/zally/rules/PascalCaseHttpHeadersRuleTest.java
@@ -8,6 +8,7 @@ import io.swagger.models.parameters.Parameter;
 import io.swagger.parser.SwaggerParser;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -18,6 +19,21 @@ import static de.zalando.zally.rules.PascalCaseHttpHeadersRule.DESCRIPTION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PascalCaseHttpHeadersRuleTest {
+
+    private final List<String> zalandoHeaders = Arrays.asList("X-Flow-ID", "X-UID", "X-Tenant-ID", "X-Sales-Channel",
+            "X-Frontend-Type", "X-Device-Type", "X-Device-OS", "X-App-Domain");
+
+    private Swagger getZalandoHeadersSwagger() {
+        Swagger swagger = new Swagger();
+        HashMap<String, Parameter> parameters = new HashMap<>();
+        zalandoHeaders.forEach((header) -> {
+                    HeaderParameter parameter = new HeaderParameter();
+                    parameter.setName(header);
+                    parameters.put(header,parameter);
+                });
+        swagger.setParameters(parameters);
+        return swagger;
+    }
 
     @Test
     public void simplePositiveCase() {
@@ -54,6 +70,11 @@ public class PascalCaseHttpHeadersRuleTest {
         parameters.put(parameter.getName(), parameter);
         swagger.setParameters(parameters);
         assertThat(new PascalCaseHttpHeadersRule().validate(swagger)).isEmpty();
+    }
+
+    @Test
+    public void mustAccepZalandoHeaders() {
+        assertThat(new PascalCaseHttpHeadersRule().validate(getZalandoHeadersSwagger())).isEmpty();
     }
 
     @Test

--- a/src/test/java/de/zalando/zally/utils/PatternUtilTest.java
+++ b/src/test/java/de/zalando/zally/utils/PatternUtilTest.java
@@ -57,6 +57,7 @@ public class PatternUtilTest {
     @Test
     public void checkIsHyphenatedPascalCase() {
         assertTrue(isHyphenatedPascalCase("Test-Case"));
+        assertTrue(isHyphenatedPascalCase("X-Flow-Id"));
         assertFalse(isHyphenatedPascalCase("test-Case"));
         assertFalse(isHyphenatedPascalCase("TestCase"));
         assertFalse(isHyphenatedPascalCase("testCase"));

--- a/src/test/resources/api_spp.json
+++ b/src/test/resources/api_spp.json
@@ -401,7 +401,7 @@
   },
   "parameters" : {
     "FlowId" : {
-      "name" : "X-FLOW-Id",
+      "name" : "X-Flow-Id",
       "description" : "A custom header that will be passed onto any further requests and can be used for diagnosing.\n",
       "in" : "header",
       "type" : "string",

--- a/src/test/resources/api_spp.json
+++ b/src/test/resources/api_spp.json
@@ -401,7 +401,7 @@
   },
   "parameters" : {
     "FlowId" : {
-      "name" : "X-Flow-Id",
+      "name" : "X-FLOW-Id",
       "description" : "A custom header that will be passed onto any further requests and can be used for diagnosing.\n",
       "in" : "header",
       "type" : "string",


### PR DESCRIPTION
- Add new hyphen pascal case http headers SHOULD rule
- Improve existing hypenated http headers MUST rule to check response headers and include path info in the violation (when exists)
- Refactored shared HTTP parsing functionality into an abstract HttpHeadersRule