### PR TITLE
#57 Fix `gradle bin` command

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -41,8 +41,7 @@ task zallyJar(type: OneJar) {
 task bin {
     dependsOn zallyJar
     copy {
-        from 'build/libs'
-        into 'bin'
-        include '**/zally.jar'
+        from 'build/libs/zally.jar'
+        into 'bin/'
     }
 }


### PR DESCRIPTION
Resolves zalando-incubator/zally#57

🔋 Uses more precise way to copy `zally.jar` file