### PR TITLE
Add support for insecure https connections

### DIFF
--- a/cli/src/main/java/de/zalando/zally/cli/ZallyApiClient.java
+++ b/cli/src/main/java/de/zalando/zally/cli/ZallyApiClient.java
@@ -5,8 +5,39 @@ import com.eclipsesource.json.JsonValue;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 
 public class ZallyApiClient {
+
+    static {
+        try {
+            SSLContext ignoreSslChecks = new SSLContextBuilder().loadTrustMaterial(null, new TrustSelfSignedStrategy() {
+                public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                    return true;
+                }
+            }).build();
+
+            CloseableHttpClient unsafeHttpClient = HttpClients.custom().setSSLContext(ignoreSslChecks)
+                    .setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
+
+            Unirest.setHttpClient(unsafeHttpClient);
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+            System.out.println("Could not disable verification of ssl certificates. "
+                    + "Support for linter services available through HTTPS can be limited.");
+        }
+    }
+
     private final String url;
     private final String token;
 


### PR DESCRIPTION
Closes #55 

Since handling different ssl keystores with java is quite heavy burden for cli tool users and we don't handle customer critical traffic, this PR configure http client of CLI with disabled ssl check.

You can verify this locally by using https://zally.architecture.zalan.do