### PR TITLE
ZALLY-77 Fix bin path in zally command

### DIFF
--- a/cli/bin/zally
+++ b/cli/bin/zally
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 function zally {
-    export ZALLY_HOME=$(dirname $(dirname $BASH_SOURCE))
-    java -Done-jar.silent=true -jar $ZALLY_HOME/bin/zally.jar "$@"
+    export ZALLY_BIN_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    java -Done-jar.silent=true -jar $ZALLY_BIN_PATH/zally.jar "$@"
 }
 
 zally $@


### PR DESCRIPTION
🔋 

Only shell script update. 

Closes #77 

More details: http://stackoverflow.com/questions/59895/getting-the-current-present-working-directory-of-a-bash-script-from-within-the-s