### PR TITLE
#86 Write one-jar directly to /bin

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -33,16 +33,9 @@ task wrapper(type: Wrapper) {
     gradleVersion = '2.14.1'
 }
 
-task zallyJar(type: OneJar) {
+task bin(type: OneJar) {
     dependsOn build
     mainClass = 'de.zalando.zally.cli.Main'
     archiveName = 'zally.jar'
-}
-
-task bin {
-    dependsOn zallyJar
-    copy {
-        from 'build/libs/zally.jar'
-        into 'bin/'
-    }
+    destinationDir = file('bin/')
 }


### PR DESCRIPTION
Closes #86 

🔋 

Since the chain of build -> oneJar -> bin provides a lot of troubles,
let's minimise the efforts and use `destinationDir` parameter of
Jar plugin:

https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:destinationDir