### PR TITLE
Switching to shadow plugin

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -14,7 +14,7 @@ requesting violations check at a given Zally server.
 
 3. Build `zally.jar` package:
 	```bash
-	./gradlew bin
+	./gradlew shadowJar
 	```
 
 4. Run it using

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'java'
-apply plugin: 'gradle-one-jar'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 repositories {
     mavenCentral()
@@ -22,20 +22,26 @@ dependencies {
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
 
     dependencies {
-        classpath 'com.github.rholder:gradle-one-jar:1.0.4'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
     }
+}
+
+jar {
+   manifest {
+       attributes 'Main-Class': 'de.zalando.zally.cli.Main'
+   }
+}
+
+shadowJar {
+   destinationDir = file('bin')
+   baseName = 'zally'
+   classifier = null
 }
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.14.1'
-}
-
-task bin(type: OneJar) {
-    dependsOn build
-    mainClass = 'de.zalando.zally.cli.Main'
-    archiveName = 'zally.jar'
-    destinationDir = file('bin/')
 }


### PR DESCRIPTION
I've faced 2 problems when building zally-cli:
1. Empty bin/zally.jar (no manifest, no classes).
2. Stackoverflow when playing with the configuration of gradle-one-jar to fix 1.

Because of this, I propose to switch to `shadow` plugin: it works, has better docu and bigger community.
I've never used Gradle before, so let me know if you have a better solution :)

PS. The first issue is maybe related to https://github.com/rholder/gradle-one-jar/issues/21