### PR TITLE
#125 Remove Prefixes from Codacy Coverage Reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,5 @@ script:
   - kill -9 `cat /tmp/zally_server.pid`
 
 after_success:
-  - ~/jpm/bin/codacy-coverage-reporter --language Java --prefix cli/ --coverageReport cli/build/reports/jacoco/test/jacocoTestReport.xml -t $CODACY_PROJECT_TOKEN
-  - ~/jpm/bin/codacy-coverage-reporter --language Java --prefix server/ --coverageReport server/build/reports/jacoco/test/jacocoTestReport.xml -t $CODACY_PROJECT_TOKEN
+  - ~/jpm/bin/codacy-coverage-reporter --language Java --coverageReport cli/build/reports/jacoco/test/jacocoTestReport.xml -t $CODACY_PROJECT_TOKEN
+  - ~/jpm/bin/codacy-coverage-reporter --language Java --coverageReport server/build/reports/jacoco/test/jacocoTestReport.xml -t $CODACY_PROJECT_TOKEN

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/zalando-incubator/zally.svg?branch=master)](https://travis-ci.org/zalando-incubator/zally)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/05a7515011504c06b1cb35ede27ac7d4)](https://www.codacy.com/app/zally/zally?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=zalando-incubator/zally&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Coverage/05a7515011504c06b1cb35ede27ac7d4)](https://www.codacy.com/app/zally/zally?utm_source=github.com&utm_medium=referral&utm_content=zalando-incubator/zally&utm_campaign=Badge_Coverage)
 
 <img src="logo.png" width="200" height="200" />
 


### PR DESCRIPTION
Fixes #125 

Reason why coverage was not uploaded: bad usage of `--prefix`. 

Tested locally, the coverage report is already available. 