### PR TITLE
Add Metrics to Server

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     compile("org.zalando.stups:stups-spring-oauth2-server:1.0.16")
     compile("org.zalando:problem-spring-web:0.16.0")
     compile("org.zalando:twintip-spring-web:1.1.0")
+    compile("org.zalando.zmon:zmon-actuator:0.9.7")
+    compile("io.dropwizard.metrics:metrics-core:3.1.0")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.8.5")
     compile("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
     testCompile("org.springframework.boot:spring-boot-starter-test")

--- a/server/src/main/java/de/zalando/zally/ApiViolationsController.java
+++ b/server/src/main/java/de/zalando/zally/ApiViolationsController.java
@@ -1,5 +1,8 @@
 package de.zalando.zally;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -7,6 +10,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.zalando.zally.exception.MissingApiDefinitionException;
 import de.zalando.zally.rules.RulesValidator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.dropwizard.DropwizardMetricServices;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,22 +22,39 @@ public class ApiViolationsController {
 
     private final RulesValidator rulesValidator;
     private final ObjectMapper mapper;
+    private final DropwizardMetricServices metricServices;
 
     @Autowired
-    public ApiViolationsController(RulesValidator rulesValidator, ObjectMapper objectMapper) {
+    public ApiViolationsController(RulesValidator rulesValidator, ObjectMapper objectMapper,
+                                   DropwizardMetricServices metricServices) {
         this.rulesValidator = rulesValidator;
         this.mapper = objectMapper;
+        this.metricServices = metricServices;
     }
 
     @RequestMapping(method = RequestMethod.POST)
     public ResponseEntity<JsonNode> validate(@RequestBody JsonNode request) {
+        metricServices.increment("counter.api-reviews.requested");
         if (!request.has("api_definition")) {
             throw new MissingApiDefinitionException();
         }
 
+        final List<Violation> violations = rulesValidator.validate(request.get("api_definition").toString());
+        reportViolationMetrics(violations);
+
         ObjectNode response = mapper.createObjectNode();
         ArrayNode jsonViolations = response.putArray("violations");
-        rulesValidator.validate(request.get("api_definition").toString()).forEach(jsonViolations::addPOJO);
+        violations.forEach(jsonViolations::addPOJO);
+
+        metricServices.increment("counter.api-reviews.processed");
         return ResponseEntity.ok(response);
+    }
+
+    private void reportViolationMetrics(List<Violation> violations) {
+        metricServices.submit("histogram.api-reviews.violations", violations.size());
+        Arrays.stream(ViolationType.values()).forEach(v -> {
+            long numberOfViolations = violations.stream().filter(violation -> violation.getViolationType() == v).count();
+            metricServices.submit("histogram.api-reviews.violations." + v.getMetricIdentifier(), numberOfViolations);
+        });
     }
 }

--- a/server/src/main/java/de/zalando/zally/MetricsExporter.java
+++ b/server/src/main/java/de/zalando/zally/MetricsExporter.java
@@ -1,0 +1,32 @@
+package de.zalando.zally;
+
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Slf4jReporter;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricsExporter implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final MetricRegistry metricRegistry;
+
+    @Autowired
+    public MetricsExporter(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        final Slf4jReporter reporter = Slf4jReporter.forRegistry(metricRegistry)
+                .outputTo(LoggerFactory.getLogger(MetricsExporter.class))
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .build();
+        reporter.start(1, TimeUnit.MINUTES);
+    }
+}

--- a/server/src/main/java/de/zalando/zally/ViolationType.java
+++ b/server/src/main/java/de/zalando/zally/ViolationType.java
@@ -2,8 +2,18 @@ package de.zalando.zally;
 
 public enum ViolationType {
 
-    MUST,
-    SHOULD,
-    COULD,
-    HINT;
+    MUST("must"),
+    SHOULD("should"),
+    COULD("could"),
+    HINT("hint");
+
+    private final String metricIdentifier;
+
+    ViolationType(String metricIdentifier) {
+        this.metricIdentifier = metricIdentifier;
+    }
+
+    public String getMetricIdentifier() {
+        return metricIdentifier;
+    }
 }

--- a/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.java
+++ b/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.java
@@ -44,8 +44,9 @@ class OAuthConfiguration extends ResourceServerConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/health").permitAll()
+                .antMatchers("/metrics").access("#oauth2.hasScope('uid')")
                 .antMatchers("/api-violations").access("#oauth2.hasScope('uid')")
-                .antMatchers("**").permitAll();
+                .antMatchers("**").denyAll();
 
         http
                 .exceptionHandling()

--- a/server/src/main/java/de/zalando/zally/rules/SnakeCaseForQueryParamsRule.java
+++ b/server/src/main/java/de/zalando/zally/rules/SnakeCaseForQueryParamsRule.java
@@ -1,5 +1,8 @@
 package de.zalando.zally.rules;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import de.zalando.zally.Violation;
 import de.zalando.zally.ViolationType;
 import de.zalando.zally.utils.PatternUtil;
@@ -8,18 +11,14 @@ import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.QueryParameter;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- * Lint for snake case for query params
- */
 @Component
 class SnakeCaseForQueryParamsRule implements Rule {
 
     @Override
     public List<Violation> validate(Swagger swagger) {
-        if (swagger == null) return new ArrayList<>();
+        if (swagger == null || swagger.getPaths() == null) {
+            return new ArrayList<>();
+        }
 
         List<Violation> violations = new ArrayList<>();
         swagger.getPaths().forEach((path, pathObject) -> {
@@ -38,10 +37,10 @@ class SnakeCaseForQueryParamsRule implements Rule {
 
     private Violation getViolation(Parameter parameter) {
         return new Violation(
-            "Use snake_case (never camelCase) for Query Parameters",
-            String.format("Query parameter '%s' does not use snake_case.", parameter.getName()),
-            ViolationType.MUST,
-            "http://zalando.github.io/restful-api-guidelines/naming/Naming.html#must-use-snakecase-never-camelcase-for-query-parameters"
+                "Use snake_case (never camelCase) for Query Parameters",
+                String.format("Query parameter '%s' does not use snake_case.", parameter.getName()),
+                ViolationType.MUST,
+                "http://zalando.github.io/restful-api-guidelines/naming/Naming.html#must-use-snakecase-never-camelcase-for-query-parameters"
         );
     }
 }

--- a/server/src/test/java/de/zalando/zally/RestApiTest.java
+++ b/server/src/test/java/de/zalando/zally/RestApiTest.java
@@ -1,5 +1,11 @@
 package de.zalando.zally;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -21,12 +27,6 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ResourceUtils;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -80,6 +80,21 @@ public class RestApiTest {
         JsonNode violations = rootObject.get("violations");
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).get("title").asText()).isEqualTo("dummy1");
+    }
+
+    @Test
+    public void shouldReturnMetricsOfFoundViolations() throws IOException {
+        sendRequest(new ObjectMapper().readTree(ResourceUtils.getFile("src/test/resources/api_spp.json")));
+
+        ResponseEntity<JsonNode> metricsResponse = restTemplate.getForEntity("http://localhost:" + port + "/metrics", JsonNode.class);
+        JsonNode rootObject = metricsResponse.getBody();
+        assertThat(rootObject.has("counter.api-reviews.requested")).isTrue();
+        assertThat(rootObject.has("counter.api-reviews.processed")).isTrue();
+        assertThat(rootObject.has("histogram.api-reviews.violations.count")).isTrue();
+        assertThat(rootObject.has("histogram.api-reviews.violations.must.count")).isTrue();
+        assertThat(rootObject.has("histogram.api-reviews.violations.should.count")).isTrue();
+        assertThat(rootObject.has("histogram.api-reviews.violations.could.count")).isTrue();
+        assertThat(rootObject.has("histogram.api-reviews.violations.hint.count")).isTrue();
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/RestApiTest.java
+++ b/server/src/test/java/de/zalando/zally/RestApiTest.java
@@ -84,7 +84,9 @@ public class RestApiTest {
 
     @Test
     public void shouldReturnMetricsOfFoundViolations() throws IOException {
-        sendRequest(new ObjectMapper().readTree(ResourceUtils.getFile("src/test/resources/api_spp.json")));
+        ResponseEntity<JsonNode> responseEntity = sendRequest(
+                new ObjectMapper().readTree(ResourceUtils.getFile("src/test/resources/api_spp.json")));
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         ResponseEntity<JsonNode> metricsResponse = restTemplate.getForEntity("http://localhost:" + port + "/metrics", JsonNode.class);
         JsonNode rootObject = metricsResponse.getBody();

--- a/server/src/test/java/de/zalando/zally/RestApiTest.java
+++ b/server/src/test/java/de/zalando/zally/RestApiTest.java
@@ -89,6 +89,7 @@ public class RestApiTest {
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         ResponseEntity<JsonNode> metricsResponse = restTemplate.getForEntity("http://localhost:" + port + "/metrics", JsonNode.class);
+        assertThat(metricsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
         JsonNode rootObject = metricsResponse.getBody();
         assertThat(rootObject.has("counter.api-reviews.requested")).isTrue();
         assertThat(rootObject.has("counter.api-reviews.processed")).isTrue();

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -1,3 +1,11 @@
+endpoints:
+  enabled: false
+  health:
+    enabled: true
+  metrics:
+    enabled: true
+    sensitive: false
+
 security:
   basic:
     enabled: false


### PR DESCRIPTION
This PR:
- adds decent metrics support to server
- all metrics are accessible under /metrics
- all metrics are exported per minute to logfile (for aggregation via Elasticsearch and Kibana e.g.)
- number of requested reviews is recorded
- histograms of violations and its different types are recorded