### PR TITLE
152 unused defs

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     testCompile("org.springframework.boot:spring-boot-starter-test")
     testCompile("org.assertj:assertj-core:3.6.1")
 
-    ktlint("com.github.shyiko:ktlint:0.3.0")
+    ktlint("com.github.shyiko:ktlint:0.6.1")
 }
 
 jacoco {

--- a/server/src/main/java/de/zalando/zally/rules/NoUnusedDefinitionsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rules/NoUnusedDefinitionsRule.kt
@@ -81,5 +81,3 @@ class NoUnusedDefinitionsRule : AbstractRule() {
                 else -> emptyList()
             }
 }
-
-

--- a/server/src/main/java/de/zalando/zally/rules/NoUnusedDefinitionsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rules/NoUnusedDefinitionsRule.kt
@@ -1,0 +1,75 @@
+package de.zalando.zally.rules
+
+import de.zalando.zally.Violation
+import de.zalando.zally.ViolationType
+import io.swagger.models.ArrayModel
+import io.swagger.models.Model
+import io.swagger.models.ModelImpl
+import io.swagger.models.RefModel
+import io.swagger.models.Response
+import io.swagger.models.Swagger
+import io.swagger.models.parameters.BodyParameter
+import io.swagger.models.parameters.Parameter
+import io.swagger.models.properties.ArrayProperty
+import io.swagger.models.properties.ObjectProperty
+import io.swagger.models.properties.Property
+import io.swagger.models.properties.RefProperty
+import org.springframework.stereotype.Component
+
+@Component
+class NoUnusedDefinitionsRule : AbstractRule() {
+    override val title = "Do not leave unused definitions"
+    override val violationType = ViolationType.SHOULD
+    override val url = ""
+
+    override fun validate(swagger: Swagger): Violation? {
+        val paramsInPaths = swagger.paths.orEmpty().values.flatMap { path ->
+            path.operations.orEmpty().flatMap { operation ->
+                operation.parameters.orEmpty()
+            }
+        }.toSet()
+
+        val refsInPaths = swagger.paths.orEmpty().values.flatMap { path ->
+            path.operations.orEmpty().flatMap { operation ->
+                val inParams = operation.parameters.orEmpty().flatMap(this::findAllRefs)
+                val inResponse = operation.responses.orEmpty().values.flatMap(this::findAllRefs)
+                inParams + inResponse
+            }
+        }
+        val refsInDefs = swagger.definitions.orEmpty().values.flatMap(this::findAllRefs)
+        val allRefs = (refsInPaths + refsInDefs).toSet()
+
+        val unusedParams = swagger.parameters.orEmpty().filterValues { it !in paramsInPaths }.keys.map { "#/parameters/$it" }
+        val unusedDefs = swagger.definitions.orEmpty().keys.filter { it !in allRefs }.map { "#/definitions/$it" }
+
+        val paths = unusedParams + unusedDefs
+
+        return if (paths.isNotEmpty()) {
+            Violation(this, title, "Found ${paths.size} unused definitions", violationType, url, paths)
+        } else null
+    }
+
+    fun findAllRefs(param: Parameter): List<String> =
+            if (param is BodyParameter) findAllRefs(param.schema) else emptyList()
+
+    fun findAllRefs(response: Response): List<String> =
+            if (response.schema != null) findAllRefs(response.schema) else emptyList()
+
+    fun findAllRefs(model: Model): List<String> =
+            when (model) {
+                is RefModel -> listOf(model.simpleRef)
+                is ArrayModel -> findAllRefs(model.items)
+                is ModelImpl -> model.properties.orEmpty().values.flatMap(this::findAllRefs)
+                else -> emptyList()
+            }
+
+    fun findAllRefs(prop: Property): List<String> =
+            when (prop) {
+                is RefProperty -> listOf(prop.simpleRef)
+                is ArrayProperty -> findAllRefs(prop.items)
+                is ObjectProperty -> prop.properties.orEmpty().values.flatMap(this::findAllRefs)
+                else -> emptyList()
+            }
+}
+
+

--- a/server/src/main/java/de/zalando/zally/rules/NoUnusedDefinitionsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rules/NoUnusedDefinitionsRule.kt
@@ -51,11 +51,11 @@ class NoUnusedDefinitionsRule : AbstractRule() {
         } else null
     }
 
-    fun findAllRefs(param: Parameter): List<String> =
+    fun findAllRefs(param: Parameter?): List<String> =
             if (param is BodyParameter) findAllRefs(param.schema) else emptyList()
 
-    fun findAllRefs(response: Response): List<String> =
-            if (response.schema != null) findAllRefs(response.schema) else emptyList()
+    fun findAllRefs(response: Response?): List<String> =
+            if (response?.schema != null) findAllRefs(response.schema) else emptyList()
 
     fun findAllRefs(model: Model?): List<String> =
             when (model) {

--- a/server/src/test/java/de/zalando/zally/rules/NoUnusedDefinitionsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rules/NoUnusedDefinitionsRuleTest.kt
@@ -1,0 +1,42 @@
+package de.zalando.zally.rules
+
+import de.zalando.zally.getFixture
+import io.swagger.models.Swagger
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class NoUnusedDefinitionsRuleTest {
+    
+    @Test
+    fun positiveCase() {
+        Assertions.assertThat(NoUnusedDefinitionsRule().validate(getFixture("unusedDefinitionsValid.json"))).isNull()
+    }
+
+    @Test
+    fun negativeCase() {
+        val results = NoUnusedDefinitionsRule().validate(getFixture("unusedDefinitionsInvalid.json"))!!.paths
+        Assertions.assertThat(results).hasSameElementsAs(listOf(
+                "#/definitions/PetName",
+                "#/parameters/FlowId"
+        ))
+    }
+
+    @Test
+    fun emptySwaggerShouldPass() {
+        val swagger = Swagger()
+        Assertions.assertThat(NoUnusedDefinitionsRule().validate(swagger)).isNull()
+    }
+
+    @Test
+    fun positiveCaseSpp() {
+        val swagger = getFixture("api_spp.json")
+        Assertions.assertThat(NoUnusedDefinitionsRule().validate(swagger)).isNull()
+    }
+
+    @Test
+    fun positiveCaseTinbox() {
+        val swagger = getFixture("api_tinbox.yaml")
+        Assertions.assertThat(NoUnusedDefinitionsRule().validate(swagger)).isNull()
+    }
+
+}

--- a/server/src/test/java/de/zalando/zally/rules/NoUnusedDefinitionsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rules/NoUnusedDefinitionsRuleTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.api.Assertions
 import org.junit.Test
 
 class NoUnusedDefinitionsRuleTest {
-    
     @Test
     fun positiveCase() {
         Assertions.assertThat(NoUnusedDefinitionsRule().validate(getFixture("unusedDefinitionsValid.json"))).isNull()

--- a/server/src/test/resources/fixtures/unusedDefinitionsInvalid.json
+++ b/server/src/test/resources/fixtures/unusedDefinitionsInvalid.json
@@ -1,0 +1,150 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/TenantId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of pets.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "FlowId": {
+      "name": "X-Flow-Id",
+      "description": "A custom header that will be passed onto any further requests and can be used for diagnosing.\n",
+      "in": "header",
+      "type": "string",
+      "required": false
+    },
+    "TenantId": {
+      "name": "X-Tenant-Id",
+      "description": "A custom header for the identification of the tenant.\nThe value of this header must be a correct/valid `business-partner-id` (as per the\n[Business Partner Service](https://techwiki.zalando.net/pages/viewpage.action?spaceKey=TH&title=Business+Partner+Service))\nFor more information on how this is used, please refer to https://pages.github.bus.zalan.do/FashionInsightsCentre/spp-documentation/spp-design/spp-data-management-apis/#ownership\n",
+      "in": "header",
+      "type": "string",
+      "format": "uuid",
+      "required": true
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "PetName": {
+      "type": "object",
+      "required": [
+        "first_name"
+      ],
+      "properties": {
+        "first_name": {
+          "type": "string"
+        },
+        "last_name": {
+          "type": "string"
+        }
+      }
+    },
+    "ErrorModel": {
+      "type": "object",
+      "required": [
+        "error_code"
+      ],
+      "properties": {
+        "error_code": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/server/src/test/resources/fixtures/unusedDefinitionsValid.json
+++ b/server/src/test/resources/fixtures/unusedDefinitionsValid.json
@@ -1,0 +1,178 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref" : "#/parameters/TenantId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of pets.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OldPet"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          },
+          {
+            "$ref" : "#/parameters/FlowId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "FlowId": {
+      "name": "X-Flow-Id",
+      "description": "A custom header that will be passed onto any further requests and can be used for diagnosing.\n",
+      "in": "header",
+      "type": "string",
+      "required": false
+    },
+    "TenantId": {
+      "name": "X-Tenant-Id",
+      "description": "A custom header for the identification of the tenant.\nThe value of this header must be a correct/valid `business-partner-id` (as per the\n[Business Partner Service](https://techwiki.zalando.net/pages/viewpage.action?spaceKey=TH&title=Business+Partner+Service))\nFor more information on how this is used, please refer to https://pages.github.bus.zalan.do/FashionInsightsCentre/spp-documentation/spp-design/spp-data-management-apis/#ownership\n",
+      "in": "header",
+      "type": "string",
+      "format": "uuid",
+      "required": true
+    }
+  },
+  "definitions": {
+    "NewPet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "OldPet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Pet": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "$ref" : "#/definitions/PetName"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "PetName": {
+      "type": "object",
+      "required": [
+        "first_name"
+      ],
+      "properties": {
+        "first_name": {
+          "type": "string"
+        },
+        "last_name": {
+          "type": "string"
+        }
+      }
+    },
+    "ErrorModel": {
+      "type": "object",
+      "required": [
+        "error_code"
+      ],
+      "properties": {
+        "error_code": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Part of  #152

Notes on current implementation:
 - I didn't find any special term that describes both definitions (like json objects) and parameters. Original swagger editor calls them both "definitions" when complaining about unused declarations. So I stick to this word (even though its incorrect) 
 -  Implementation is based on "best effort". I found it very hard to list all possible cases due to complexity of swagger spec and local idiosyncrasies of our swagger parser. 
 - It covers only parameters and definitions (swagger specs also allows path and response references). I didn't find any examples of path/response reference in our fixtures and decided to address it in separate PR.
 - Most WTF code in this rule comes from inconsistencies in data model. Example: SwaggerParser represents ref to parameter as actual inline parameter definition. There is no way to distinguish this two cases. That's why code for parameters and definitions differs.
 - It would be nice to have separate rule for broken link detection - when some resource is referenced but never declared
