### PR TITLE
Upgrade Gradle and Kotlin

### DIFF
--- a/cli/gradle/wrapper/gradle-wrapper.properties
+++ b/cli/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 23 11:18:23 CET 2016
+#Tue Mar 21 14:41:52 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -3,12 +3,13 @@ configurations {
 }
 
 def versions = [
-  jacoco: '0.7.8',
+        jacoco : '0.7.8',
+        jackson: '2.8.7',
 ]
 
 buildscript {
 
-    ext.kotlin_version = '1.1.0'
+    ext.kotlin_version = '1.1.1'
 
     repositories {
         mavenCentral()
@@ -38,7 +39,7 @@ task wrapper(type: Wrapper) {
 
 jar {
     baseName = 'zally'
-    version =  '0.0.1'
+    version = '0.0.1'
 }
 
 repositories {
@@ -58,8 +59,11 @@ dependencies {
     compile("org.zalando:twintip-spring-web:1.1.0")
     compile("org.zalando.zmon:zmon-actuator:0.9.7")
     compile("io.dropwizard.metrics:metrics-core:3.1.0")
-    compile("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.8.5")
-    compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.8.6")
+    compile("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}")
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:${versions.jackson}") {
+        exclude group: "org.jetbrains.kotlin", module: "kotlin-reflect"
+    }
+    compile("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
     compile("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
     testCompile("org.springframework.boot:spring-boot-starter-test")
     testCompile("org.assertj:assertj-core:3.6.1")
@@ -72,9 +76,9 @@ jacoco {
 }
 
 jacocoTestReport {
-  reports {
-    xml.enabled true
-  }
+    reports {
+        xml.enabled true
+    }
 }
 
 task ktlint(type: JavaExec) {

--- a/server/gradle/wrapper/gradle-wrapper.properties
+++ b/server/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 23 11:15:42 CET 2016
+#Tue Mar 21 14:42:15 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip


### PR DESCRIPTION
* Upgrade from outdated Gradle 2.14.1 to latest version 3.4.1
    * there was [a known bug](http://stackoverflow.com/questions/42587487/noclassdeffounderror-after-intellij-idea-upgrade/42588061#42588061) with Gradle 3.4.x and IntelliJ 2016.3
    * IntelliJ 2017.1 was released today with a fix for this bug
* jackson-module-kotlin has a transitive dependency to kotlin-reflect 1.0.5 that is in conflict with the kotlin version used in the project
    * exclude the transitive dependency
    * explicitly include kotlin-reflect 
* Upgrade to Kotlin 1.1.1
