### PR TITLE
web-ui: add msg component tests

### DIFF
--- a/web-ui/src/client/app/components/dress-code.jsx
+++ b/web-ui/src/client/app/components/dress-code.jsx
@@ -4,12 +4,13 @@ export class Msg extends React.Component {
   constructor(props) { super(props) }
 
   render() {
+    const type = this.props.type || 'info';
     return (
-      <div className={"dc-msg dc-msg--" + this.props.type }>
+      <div className={"dc-msg dc-msg--" + type }>
         <div className="dc-msg__inner">
 
           <div className="dc-msg__icon-frame">
-            <i className={"dc-icon dc-msg__icon dc-icon--" + this.props.type}></i>
+            <i className={"dc-icon dc-msg__icon dc-icon--" + type}></i>
           </div>
 
           <div className="dc-msg__bd">

--- a/web-ui/test/unit/client/app/components/dress-code.spec.jsx
+++ b/web-ui/test/unit/client/app/components/dress-code.spec.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {Msg} from '../../../../../src/client/app/components/dress-code.jsx';
+
+describe('Msg component', () => {
+
+  test('with default props should show the close button', () => {
+    const component = shallow(<Msg />);
+    const closeButton = component.find('.dc-msg__close');
+
+    expect(closeButton.length).toEqual(1);
+  });
+
+  test('with default props should use "info" type', () => {
+    const component = shallow(<Msg />);
+    const container = component.find('.dc-msg--info');
+
+    expect(container.length).toEqual(1);
+  });
+
+  test('should show title and text', () => {
+    const component = shallow(
+      <Msg title="Hello" text="World"/>
+    );
+    const text = component.find('.dc-msg__text');
+    const title = component.find('.dc-msg__title');
+
+    expect(title.text()).toEqual('Hello');
+    expect(text.text()).toEqual('World');
+  });
+
+  test('should use the type defined via related prop', () => {
+    const component = shallow(<Msg type="alert"/>);
+    const defaultContainer = component.find('.dc-msg--info');
+    const container = component.find('.dc-msg--alert');
+
+    expect(defaultContainer.length).toEqual(0);
+    expect(container.length).toEqual(1);
+  });
+
+  test('should invoke callback when close button is clicked', () => {
+    const onCloseButtonClick = jest.fn();
+    const component = shallow(<Msg onCloseButtonClick={onCloseButtonClick}/>);
+    component.find('.dc-msg__close').simulate('click');
+
+    expect(onCloseButtonClick).toHaveBeenCalled();
+  });
+
+  test('should hide close button', () => {
+    const component = shallow(<Msg closeButton={false}/>);
+
+    expect(component.find('.dc-msg__close').length).toEqual(0);
+  });
+
+});


### PR DESCRIPTION
web-ui: add msg component tests.

@mfellner @bhaskarmelkani Two doubts are in my head now that I start working with Jest, React plus node all together.....

* For the "react client" we should use snapshot testing or doing like in this PR and test the DOM? 
I see some potential problems in the approach used in this PR with DOM testing, caused by the usage of css class names to locate dom nodes... can be problematic to maintain but on the other hand it "really" assures that the dom structure is the one that we expect.

* We should use the folder structure that seems "suggested" in JEST documentation?

```
---\
  |-- client
      |-- components
          |-- dress-code.jsx
          |-- __tests__
             |-- dress-code.test.jsx
  |-- server
      |-- env-handler.js
      |-- __tests__
         |-- env-handler-spec.js
```

With the above folder structure I see two benefits:
a) tests are close to the source code (personally something that I like)
b) don't go too crazy with relative paths (eg .```import {Msg} from '../../../../../src/client/app/components/dress-code.jsx``` will be ```ìmport {Msg} from '../dress-code.jsx'```)

@mfellner @bhaskarmelkani WDYT?

