### PR TITLE
web-ui: Use api_definition_url, just proxy request for CORS

### DIFF
--- a/web-ui/src/client/app/services/rest.js
+++ b/web-ui/src/client/app/services/rest.js
@@ -1,7 +1,7 @@
 import {client} from './http-client.js';
 
 export default {
-  getApiViolations (apiDefinition) {
+  getApiViolations (apiDefinitionUrl) {
     const options = {
       method: 'POST',
       headers: {
@@ -9,7 +9,7 @@ export default {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        api_definition: apiDefinition
+        api_definition_url: apiDefinitionUrl
       })
     };
     return client

--- a/web-ui/src/server/index.js
+++ b/web-ui/src/server/index.js
@@ -62,7 +62,7 @@ app.post('/refresh-token', bodyParser.json(), require('./refresh-token-handler')
 /**
  * Proxy zally api to avoid CORS restriction
  */
-app.use('/zally-api', bodyParser.json(),  require('./zally-api-handler'));
+app.use('/zally-api',  require('./zally-api-handler'));
 
 /**
  * Health check

--- a/web-ui/src/server/zally-api-handler.js
+++ b/web-ui/src/server/zally-api-handler.js
@@ -2,19 +2,9 @@
 
 const env = require('./env');
 const logger = require('./logger');
-const fetch = require('./fetch');
-const yaml = require('js-yaml');
+const request = require('request');
 
-function parseSchema (text) {
-  try {
-    // try json first
-    return JSON.parse(text);
-  } catch (err) {
-    return yaml.safeLoad(text);
-  }
-}
-
-module.exports = async function (req, res) {
+module.exports = function (req, res) {
   // remove the prefix found in the incoming req.url and concatenate
   // the remaining path to ZALLY_API_URL
   //
@@ -26,45 +16,8 @@ module.exports = async function (req, res) {
   //
   const url = env.ZALLY_API_URL + req.url.replace('/zally-api', '');
 
-  const apiDefinitionURL = req.body.api_definition;
 
-  try {
+  logger.debug(`Proxying request to: ${url}`);
+  req.pipe(request(url)).pipe(res);
 
-    logger.debug(`Fetch swagger schema: ${apiDefinitionURL}`);
-    const fetchSchemaResponse = await fetch(apiDefinitionURL);
-    const schemaAsText = await fetchSchemaResponse.text();
-
-    logger.debug(`Parse schema: ${apiDefinitionURL}`);
-    const schema = parseSchema(schemaAsText);
-
-    const violationsResponse = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'Authorization': req.headers.authorization
-      },
-      body: JSON.stringify({ api_definition: schema })
-    });
-
-    const violations = await violationsResponse.json();
-
-    res.json(violations);
-
-  } catch (error) {
-
-    logger.error(error);
-
-    const status = error.status ? error.status : 400;
-
-    res.status(status);
-
-    // use https://zalando.github.io/problem/schema.yaml#/Problem'
-    res.json({
-      type: 'about:blank',
-      title: error.message,
-      detail: error.message,
-      status
-    });
-  }
 };


### PR DESCRIPTION
Use api_definition_url, just proxy request on the server to avoid CORS.

Closes #242 