### PR TITLE
Revert extra health and metrics endpoint port

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,6 +6,5 @@ COPY build/libs/zally-1.0.0.jar /
 COPY scm-source.json /scm-source.json
 
 EXPOSE 8080
-EXPOSE 7979
 
 CMD java -Xmx512m $(appdynamics-agent) -jar /zally-1.0.0.jar

--- a/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.java
+++ b/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.java
@@ -43,8 +43,8 @@ class OAuthConfiguration extends ResourceServerConfigurerAdapter {
                 .sessionCreationPolicy(SessionCreationPolicy.NEVER)
                 .and()
                 .authorizeRequests()
-                .antMatchers("**/health").permitAll()
-                .antMatchers("**/metrics").access("#oauth2.hasScope('uid')")
+                .antMatchers("/health").permitAll()
+                .antMatchers("/metrics").access("#oauth2.hasScope('uid')")
                 .antMatchers("/api-violations").access("#oauth2.hasScope('uid')")
                 .antMatchers("**").denyAll();
 

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -6,9 +6,6 @@ endpoints:
     enabled: true
     sensitive: false
 
-management:
-  port: 7979
-
 security:
   basic:
     enabled: false

--- a/server/src/main/resources/application-test.yml
+++ b/server/src/main/resources/application-test.yml
@@ -6,9 +6,6 @@ endpoints:
     enabled: true
     sensitive: false
 
-management:
-  port: 0
-
 security:
   basic:
     enabled: false

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -13,9 +13,6 @@ endpoints:
     enabled: true
     sensitive: false
 
-management:
-  port: 7979
-
 security:
   basic:
     enabled: false


### PR DESCRIPTION
This causes more issues than it brings us anything - since metrics endpoint is secured by oauth anyway.