### PR TITLE
web-ui: fix boolean as string ENV variables parsing

### DIFF
--- a/web-ui/src/server/__tests__/util.test.js
+++ b/web-ui/src/server/__tests__/util.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const {stringToBool} = require('../util');
+
+
+describe('server.util', () => {
+  describe('stringToBool', () => {
+    test('transform "false" values into real booleans while keeping other values as they are', () => {
+      expect(stringToBool({
+        foo: 'false',
+        bar: false
+      })).toEqual({
+        foo: false,
+        bar: false
+      });
+    });
+
+    test('transform "true" values into real booleans while keeping other values as they are', () => {
+      expect(stringToBool({
+        foo: 'true',
+        bar: 'true',
+        john: 'doe'
+      })).toEqual({
+        foo: true,
+        bar: true,
+        john: 'doe'
+      });
+    });
+  });
+});

--- a/web-ui/src/server/env.js
+++ b/web-ui/src/server/env.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const {stringToBool} = require('./util');
+const dotenvParseVariables = require('dotenv-parse-variables').default;
 const dotenv = require('dotenv').config();
-const dotenvParsedVariables = require('dotenv-parse-variables').default(dotenv.parsed || {});
+const dotenvParsedVariables = dotenvParseVariables(dotenv.parsed || {});
 
 const defaults = {
   PORT: 8442,
@@ -39,11 +41,11 @@ const publicEnvKeys = [
   'DEBUG'
 ];
 
-const env = Object.assign(
+const env = stringToBool(Object.assign(
   defaults,
   process.env,
   dotenvParsedVariables
-);
+));
 
 const publicEnv = publicEnvKeys.reduce((acc, key) => {
   acc[key] = env[key];

--- a/web-ui/src/server/util.js
+++ b/web-ui/src/server/util.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * Dummy function to transform object that contains
+ * boolean values expressed as strings (eg. 'true' or 'false')
+ * in real boolean values. Doesn't traverse the object tree.
+ *
+ * @param {Object} object
+ * @return {Object}
+ */
+function stringToBool (object) {
+  return Object.keys(object).reduce((acc, key) => {
+    if (object[key] === 'true') {
+      acc[key] = true;
+    } else if (object[key] === 'false') {
+      acc[key] = false;
+    } else {
+      acc[key] = object[key];
+    }
+    return acc;
+  }, {});
+}
+
+module.exports = {
+  stringToBool
+};


### PR DESCRIPTION
Small hotfix to correcly evaluate boolean like ENV variable passed as strings.
Eg. ```OAUTH_ENABLED="true" npm start```

```OAUTH_ENABLED``` will be parsed as a boolean:

```js
const env = require('./env');

console.log(env.OAUTH_ENABLED === true); // true
```