### PR TITLE
web-ui: show 'meaningful' error message from rest api, close #282

### DIFF
--- a/web-ui/src/client/app/containers/__tests__/violations.test.jsx
+++ b/web-ui/src/client/app/containers/__tests__/violations.test.jsx
@@ -1,14 +1,17 @@
+import React from 'react';
 import {Violations} from '../violations.jsx';
+import {shallow} from 'enzyme';
 
 describe('Violations container component', () => {
-  let container, event, getApiViolations;
+  let component, props, container, event, getApiViolations;
 
   beforeEach(() => {
     getApiViolations = jest.fn();
-    container = new Violations({
+    props = {
       route: { getApiViolations: getApiViolations }
-    });
-    container.setState = jest.fn();
+    };
+    component = shallow(<Violations {...props}></Violations>);
+    container = component.instance();
     event = {
       preventDefault: jest.fn(),
       target: {}
@@ -19,7 +22,7 @@ describe('Violations container component', () => {
     test('should set the correct state', () => {
       event.target.value = 'foo';
       container.handleOnInputValueChange(event);
-      expect(container.setState).toHaveBeenCalledWith({inputValue: 'foo'});
+      expect(container.state.inputValue).toBe(event.target.value);
     });
   });
 
@@ -27,25 +30,44 @@ describe('Violations container component', () => {
     test('should handle success', () => {
       const violations = [{}];
       const violationsCount = 1;
-      getApiViolations.mockReturnValueOnce(Promise.resolve(violations, violationsCount));
+      getApiViolations.mockReturnValueOnce(Promise.resolve({
+        violations: violations,
+        violations_count: violationsCount
+      }));
       container.state.inputValue = 'URL_WITH_GOOD_SCHEMA';
 
       const promise = container.handleFormSubmit(event);
-      expect(container.setState).toHaveBeenCalled();
 
       return promise.then(() => {
         expect(event.preventDefault).toHaveBeenCalled();
         expect(getApiViolations.mock.calls[0][0]).toBe('URL_WITH_GOOD_SCHEMA');
-        expect(container.setState).toHaveBeenCalled();
+        expect(container.state.violations).toEqual(violations);
+        expect(container.state.violationsCount).toEqual(violationsCount);
       });
     });
 
     test('should handle failure', (done) => {
+      const mockError = { detail: 'error' };
       container.state.inputValue = 'URL_WITH_AN_ERROR';
-      getApiViolations.mockReturnValueOnce(Promise.reject());
+      getApiViolations.mockReturnValueOnce(Promise.reject(mockError));
       container.handleFormSubmit(event).catch(() => {
         try {
           expect(getApiViolations.mock.calls[0][0]).toBe('URL_WITH_AN_ERROR');
+          expect(container.state.error).toEqual(mockError.detail);
+          done();
+        } catch (e) {
+          done.fail(e);
+        }
+      });
+    });
+
+    test('should handle failure and use DEFAULT_ERROR_MESSAGE if expected error field is undefined', (done) => {
+      container.state.inputValue = 'URL_WITH_AN_ERROR';
+      getApiViolations.mockReturnValueOnce(Promise.reject({}));
+      container.handleFormSubmit(event).catch(() => {
+        try {
+          expect(getApiViolations.mock.calls[0][0]).toBe('URL_WITH_AN_ERROR');
+          expect(container.state.error).toEqual(Violations.DEFAULT_ERROR_MESSAGE);
           done();
         } catch (e) {
           done.fail(e);

--- a/web-ui/src/client/app/containers/violations.jsx
+++ b/web-ui/src/client/app/containers/violations.jsx
@@ -24,6 +24,7 @@ export function ViolationsTab (props) {
 }
 
 export class Violations extends Component {
+
   constructor (props) {
     super(props);
 
@@ -63,11 +64,13 @@ export class Violations extends Component {
         });
       })
       .catch((error) => {
+
         console.error(error); // eslint-disable-line no-console
+
         this.setState({
           pending: false,
           ajaxComplete: true,
-          error: 'Ooops something went wrong!',
+          error: error.detail || Violations.DEFAULT_ERROR_MESSAGE,
           violations: [],
           violationsCount: {
             could: 0,
@@ -95,3 +98,5 @@ export class Violations extends Component {
     );
   }
 }
+
+Violations.DEFAULT_ERROR_MESSAGE = 'Ooops something went wrong!';

--- a/web-ui/src/client/app/services/__tests__/rest.test.js
+++ b/web-ui/src/client/app/services/__tests__/rest.test.js
@@ -24,6 +24,25 @@ describe('RestService', () => {
     });
   });
 
+  test('getApiViolations call api-violations api and reject with error json body', (done) => {
+    const mockError = { detail: 'some error' };
+    const errorResponse = {
+      json:() => (Promise.resolve(mockError))
+    };
+    client.fetch.mockReturnValueOnce(Promise.reject(errorResponse));
+
+    return RestService.getApiViolations({
+      foo: 'bar'
+    }).catch((error) => {
+      try {
+        expect(error.detail).toBe(mockError.detail);
+        done();
+      } catch (e) {
+        done.fail(e);
+      }
+    });
+  });
+
   test('getApiViolationsByURL send expected body', () => {
     const mockViolations = [];
     const violationsResponse = {

--- a/web-ui/src/client/app/services/rest.js
+++ b/web-ui/src/client/app/services/rest.js
@@ -14,6 +14,11 @@ export const RestService = {
       .fetch('/zally-api/api-violations', options)
       .then((response) => {
         return response.json();
+      })
+      .catch((response) => {
+        return response.json().then((body) => {
+          return Promise.reject(body);
+        });
       });
   },
   getApiViolationsByURL (apiDefinitionURL) {


### PR DESCRIPTION
web-ui: show 'meaningful' error message from rest api, close #282

* update tests using shallow rendering also for "abstract" violations component
* getApiViolations catch the error and "reject" with json body  