### PR TITLE
web-ui: catch and show parsing error

### DIFF
--- a/web-ui/src/client/app/components/editor.jsx
+++ b/web-ui/src/client/app/components/editor.jsx
@@ -6,26 +6,25 @@ import 'brace/mode/yaml';
 import 'brace/mode/json';
 import 'brace/theme/github';
 
+export function ValidateButton (props) {
+  return (<button
+    type="submit"
+    disabled={props.disabled}
+    className={'dc-btn dc-btn--primary editor-input-form__button' + (props.disabled ? ' dc-btn--disabled' : '')}>
+    VALIDATE
+  </button>);
+}
 
 export function EditorInputForm (props) {
   return (<form onSubmit={props.onSubmit} className="editor-input-form">
     <label className="dc-label editor-input-form__label">Paste in a Swagger schema and click</label>
-    <button
-      type="submit"
-      disabled={props.pending}
-      className={'dc-btn dc-btn--primary editor-input-form__button' + (props.pending ? 'dc-btn--disabled' : '')}>
-      VALIDATE
-    </button>
+    <ValidateButton disabled={props.pending || props.editorError} />
     <Editor
+      annotations={props.editorAnnotations}
       onChange={props.onInputValueChange}
       value={props.editorValue} />
     <div className="editor-input-form__bottom-button">
-      <button
-        type="submit"
-        disabled={props.pending}
-        className={'dc-btn dc-btn--primary editor-input-form__button' + (props.pending ? 'dc-btn--disabled' : '')}>
-        VALIDATE
-      </button>
+      <ValidateButton disabled={props.pending || props.editorError} />
     </div>
   </form>);
 }
@@ -39,6 +38,7 @@ export function Editor (props) {
         mode="yaml"
         theme="github"
         width="100%"
+        annotations={props.annotations}
         value={props.value}
         onChange={props.onChange || function () {}}
         editorProps={{$blockScrolling: true}}

--- a/web-ui/src/client/app/containers/__tests__/editor.test.jsx
+++ b/web-ui/src/client/app/containers/__tests__/editor.test.jsx
@@ -21,9 +21,15 @@ describe('Editor container component', () => {
     const editorValue = 'prop: foo';
     MockStorage.getItem.mockReturnValueOnce(editorValue);
     const component = shallow(<Editor route={route} />);
-
     expect(component.state().editorValue).toBe(editorValue);
-    expect(component.state().inputValue).toEqual({ prop: 'foo'});
+  });
+
+  test('should set expected state values when componentDidMount', () => {
+    const editorValue = 'prop: foo';
+    MockStorage.getItem.mockReturnValueOnce(editorValue);
+    const component = shallow(<Editor route={route} />);
+    component.instance().componentDidMount();
+    expect(component.state().inputValue).toEqual({prop: 'foo'});
   });
 
 
@@ -41,10 +47,21 @@ describe('Editor container component', () => {
     expect(component.state().inputValue).toEqual({ foo: 'prop'});
   });
 
-  test('should use an empty string as editor value if Storage doesn\'t contain an item', () => {
+  test('should use an empty string as editor value and input value if Storage doesn\'t contain an item', () => {
     const component = shallow(<Editor route={route} />);
 
     expect(component.state().editorValue).toBe('');
-    expect(component.state().inputValue).toBeUndefined();
+    expect(component.state().inputValue).toBe('');
+  });
+
+  test('should show an en error if schema parsing fails', () => {
+
+    MockStorage.getItem.mockReturnValueOnce('invalidyaml: \'2');
+    const component = shallow(<Editor route={route} />);
+
+    component.instance().componentDidMount();
+
+    expect(component.state().editorError).toBeDefined();
+    expect(component.state().editorError.name).toEqual('YAMLException');
   });
 });

--- a/web-ui/src/client/app/containers/editor.jsx
+++ b/web-ui/src/client/app/containers/editor.jsx
@@ -1,24 +1,54 @@
 import React from 'react';
 import yaml from 'js-yaml';
+import {Msg} from '../components/dress-code.jsx';
 import {Violations} from './violations.jsx';
 import {ViolationsResult} from '../components/violations.jsx';
 import {EditorInputForm} from '../components/editor.jsx';
+
+
+export const editorErrorToAnnotations = (error) => {
+  if (!error || !error.mark) { return []; }
+  return [
+    { row: error.mark.line, column: error.mark.column, type: 'error', text: error.reason }
+  ];
+};
 
 export class Editor extends Violations {
 
   constructor (props) {
     super(props);
     this.state.editorValue = this.Storage.getItem('editor-value') || '';
-    this.state.inputValue = yaml.load(this.state.editorValue);
+  }
+
+  componentDidMount () {
+    this.updateInputValue(this.state.editorValue);
+  }
+
+  updateInputValue (value) {
+    try {
+      const inputValue = yaml.load(value);
+      this.setState({
+        inputValue: inputValue,
+        editorError: null,
+        editorAnnotations: []
+      });
+    } catch (e) {
+      console.warn(e); // eslint-disable-line no-console
+      this.setState({
+        inputValue: null,
+        editorError: e,
+        editorAnnotations: editorErrorToAnnotations(e)
+      });
+    }
   }
 
   handleOnInputValueChange (value) {
     this.Storage.setItem('editor-value', value);
 
     this.setState({
-      inputValue: yaml.load(value),
       editorValue: value
     });
+    this.updateInputValue(value);
   }
 
   render () {
@@ -27,6 +57,8 @@ export class Editor extends Violations {
         <div className="dc-column dc-column--small-12 dc-column--large-7">
           <div className="dc-column__contents">
             <EditorInputForm
+              editorError={this.state.editorError}
+              editorAnnotations={this.state.editorAnnotations}
               editorValue={this.state.editorValue}
               onSubmit={this.handleFormSubmit.bind(this)}
               onInputValueChange={this.handleOnInputValueChange.bind(this)}
@@ -35,6 +67,7 @@ export class Editor extends Violations {
         </div>
         <div className="dc-column dc-column--small-12 dc-column--large-5">
           <div className="dc-column__contents">
+            { this.state.editorError ? <Msg type="error" title="ERROR" text={this.state.editorError.message} closeButton={false} /> : null }
             <ViolationsResult
               pending={this.state.pending}
               complete={this.state.ajaxComplete}


### PR DESCRIPTION
Catch and show an error to the user if schema can't be parsed (contains YAML errors).
Probably closing #290 