### PR TITLE
web-ui: remove zalando oauth specific env variables and logic, yeah!

### DIFF
--- a/web-ui/src/server/__tests__/env-handler.test.js
+++ b/web-ui/src/server/__tests__/env-handler.test.js
@@ -1,165 +1,35 @@
 'use strict';
 
+
 describe('server.env-handler', () => {
-  let envHandler;
-  const mockWrite = jest.fn();
-  const res = {
-    setHeader: () => {},
-    write: mockWrite,
-    end: () => {}
-  };
-  const req = {};
-  const mockReadFile = jest.fn()
-    .mockImplementationOnce((path, cb) => cb({message: 'Dummy file read error.'}, null))
-    .mockImplementationOnce((path, cb) => cb(null, 'A non json data.'))
-    .mockImplementationOnce((path, cb) => cb(null, '{"client_id": "id:123"}'));
-  const mockJoin = jest.fn()
-    .mockImplementationOnce(() => 'clientJsonFilePathWithError')
-    .mockImplementationOnce(() => 'clientJsonFilePath')
-    .mockImplementationOnce(() => 'clientJsonFilePath');
-  const mockDebug = jest.fn();
-  const mockError = jest.fn();
 
-  jest.mock('fs', () => ({
-    readFile: mockReadFile
+  const envHandler = require('../env-handler');
+  let mockWrite, res, req;
+
+  jest.mock('../env', () => ({
+    public: () => {
+      return {'foo' : 'bar'};
+    }
   }));
-
-  jest.mock('path', () => ({
-    join: mockJoin
-  }));
-
-  jest.mock('../logger', () => ({
-    debug: mockDebug,
-    error: mockError
-  }));
-
-  envHandler = require('../env-handler');
 
   test('should export a function', () => {
     expect(envHandler).toBeInstanceOf(Function);
   });
 
-  describe('when invoking the function without ZALANDO_OAUTH && CREDENTIALS_DIR', () => {
+  describe('when invoking the function', () => {
     beforeEach(() => {
-      jest.resetModules();
-      jest.mock('../env', () => ({
-        public: () => {
-          return {'foo' : 'bar'};
-        }
-      }));
-
-      envHandler = require('../env-handler');
+      mockWrite = jest.fn();
+      res = {
+        setHeader: () => {},
+        write: mockWrite,
+        end: () => {}
+      };
+      req = {};
       envHandler(req, res);
     });
 
     test('should send the response', () => {
       expect(mockWrite).toHaveBeenCalledWith('window.env = {"foo":"bar"}');
-    });
-
-  });
-
-  describe('when invoking the function with ZALANDO_OAUTH && CREDENTIALS_DIR and cannot read clientJSON', () => {
-    beforeEach(() => {
-      jest.resetModules();
-      jest.mock('../env', () => ({
-        public: () => {
-          return {'foo' : 'bar'};
-        },
-        'ZALANDO_OAUTH': 'zalandoOauth',
-        'CREDENTIALS_DIR': 'credentialsDir'
-      }));
-
-      envHandler = require('../env-handler');
-      envHandler(req, res);
-    });
-
-    test('should create clientJSONPath', () => {
-      expect(mockJoin).toHaveBeenCalledWith('credentialsDir', 'client.json');
-    });
-
-    test('should log a debug message', () => {
-      expect(mockDebug).toHaveBeenCalledWith('Reading clientJsonFilePathWithError');
-    });
-
-    test('should read file', () => {
-      expect(mockReadFile.mock.calls[0][0]).toBe('clientJsonFilePathWithError');
-    });
-
-    test('should log error', () => {
-      expect(mockError).toHaveBeenCalledWith('Cannot read client.json!');
-    });
-
-    test('should send a response', () => {
-      expect(mockWrite).toHaveBeenCalledWith('window.env = {"foo":"bar"}');
-    });
-  });
-
-  describe('when invoking the function with ZALANDO_OAUTH && CREDENTIALS_DIR and cannot parse clientJson file data', () => {
-    beforeEach(() => {
-      jest.resetModules();
-      jest.mock('../env', () => ({
-        public: () => {
-          return {'foo' : 'bar'};
-        },
-        'ZALANDO_OAUTH': 'zalandoOauth',
-        'CREDENTIALS_DIR': 'credentialsDir'
-      }));
-
-      envHandler = require('../env-handler');
-      envHandler(req, res);
-    });
-
-    test('should create clientJSONPath', () => {
-      expect(mockJoin).toHaveBeenCalledWith('credentialsDir', 'client.json');
-    });
-
-    test('should log a debug message', () => {
-      expect(mockDebug).toHaveBeenCalledWith('Reading clientJsonFilePath');
-    });
-
-    test('should read file', () => {
-      expect(mockReadFile.mock.calls[1][0]).toBe('clientJsonFilePath');
-    });
-
-    test('should log json parse error', () => {
-      expect(mockError).toHaveBeenCalledWith('Cannot parse client.json');
-    });
-
-    test('should send a response', () => {
-      expect(mockWrite).toHaveBeenCalledWith('window.env = {"foo":"bar"}');
-    });
-
-  });
-
-  describe('when invoking the function with ZALANDO_OAUTH && CREDENTIALS_DIR and can successfully read clientJson file', () => {
-    beforeEach(() => {
-      jest.resetModules();
-      jest.mock('../env', () => ({
-        public: () => {
-          return {'foo' : 'bar'};
-        },
-        'ZALANDO_OAUTH': 'zalandoOauth',
-        'CREDENTIALS_DIR': 'credentialsDir'
-      }));
-
-      envHandler = require('../env-handler');
-      envHandler(req, res);
-    });
-
-    test('should create clientJSONPath', () => {
-      expect(mockJoin).toHaveBeenCalledWith('credentialsDir', 'client.json');
-    });
-
-    test('should log a debug message', () => {
-      expect(mockDebug).toHaveBeenCalledWith('Reading clientJsonFilePath');
-    });
-
-    test('should read file', () => {
-      expect(mockReadFile.mock.calls[2][0]).toBe('clientJsonFilePath');
-    });
-
-    test('should send a response', () => {
-      expect(mockWrite).toHaveBeenCalledWith('window.env = {"foo":"bar","OAUTH_CLIENT_ID":"id:123"}');
     });
   });
 });

--- a/web-ui/src/server/env-handler.js
+++ b/web-ui/src/server/env-handler.js
@@ -1,76 +1,12 @@
 'use strict';
 
-const fs = require('fs');
 const env = require('./env');
-const logger = require('./logger');
-const path = require('path');
 
-/**
- * @param {Object} publicEnv - an object representing the environment variables available for the client
- * @return {String}
- */
-function buildJS (publicEnv) {
-  return `window.env = ${JSON.stringify(publicEnv)}`;
-}
-
-/**
- * @param res - http server response
- * @param {String} content
- */
-function sendResponse (res, content) {
-  res.setHeader('content-type', 'text/javascript');
-  res.write(content);
-  res.end();
-}
-
-/**
- * Zalando specific env handler,
- * should be removed when Zalando OAuth2 stop rotating client credentials
- *
- * @param req
- * @param res
- */
-function zalandoEnvHandler (req, res) {
-
-  const publicEnv = env.public();
-  const clientJSONPath = path.join(env.CREDENTIALS_DIR, 'client.json');
-
-  logger.debug(`Reading ${clientJSONPath}`);
-
-  fs
-    .readFile(clientJSONPath, (err, data) => {
-
-      if (err) {
-        logger.error('Cannot read client.json!');
-        logger.error(err);
-        sendResponse(res, buildJS(publicEnv));
-        return;
-      }
-
-      try {
-        const credentials = JSON.parse(data);
-        publicEnv.OAUTH_CLIENT_ID = credentials.client_id;
-      } catch (error) {
-        logger.error('Cannot parse client.json');
-      }
-
-      sendResponse(res, buildJS(publicEnv));
-    });
-}
-
-/**
- * @param req
- * @param res
- */
 function envHandler (req, res) {
-  const publicEnv = env.public();
-
-  if (env.ZALANDO_OAUTH && env.CREDENTIALS_DIR) {
-    zalandoEnvHandler(req, res);
-    return;
-  }
-
-  sendResponse(res, buildJS(publicEnv));
+  const jsOutput = `window.env = ${JSON.stringify(env.public())}`;
+  res.setHeader('content-type', 'text/javascript');
+  res.write(jsOutput);
+  res.end();
 }
 
 module.exports = envHandler;


### PR DESCRIPTION
web-ui: remove zalando oauth specific env variables and logic, yeah!

**NOTE**: with the new platform IAM for non confidential clients (the one using OAuth Implicit Grant Flow) the client id doesn't rotate so we don't need to read credentials.json file.