### PR TITLE
Monitoring metrics instead of counters

### DIFF
--- a/server/src/main/java/de/zalando/zally/ApiViolationsController.java
+++ b/server/src/main/java/de/zalando/zally/ApiViolationsController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @CrossOrigin
 @RestController(value = "/api-violations")
@@ -59,27 +58,10 @@ public class ApiViolationsController {
     }
 
     private void reportViolationMetrics(List<Violation> violations) {
-        reportViolationHistograms(violations);
-        reportAggregatedHistograms(violations);
-        reportViolationMeters(violations);
-    }
-
-    private void reportViolationMeters(List<Violation> violations) {
         violations.forEach(v -> {
             metricServices.increment("meter.api-reviews.violations.rule." + v.getRule().getName().toLowerCase());
             metricServices.increment("meter.api-reviews.violations.type." + v.getRule().getViolationType());
         });
-    }
-
-    private void reportViolationHistograms(List<Violation> violations) {
-        violations.stream().collect(Collectors.groupingBy(Violation::getRule)).forEach((r, v) ->
-                metricServices.submit("histogram.api-reviews.violations.rule." + r.getName().toLowerCase(), v.size()));
-    }
-
-    private void reportAggregatedHistograms(List<Violation> violations) {
-        metricServices.submit("histogram.api-reviews.violations", violations.size());
-        violations.stream().collect(Collectors.groupingBy(Violation::getViolationType)).forEach((t, v) ->
-                metricServices.submit("histogram.api-reviews.violations.type." + t.getMetricIdentifier(), v.size()));
     }
 
     private void setCounters(List<Violation> violations, ObjectNode result) {

--- a/server/src/test/java/de/zalando/zally/RestApiViolationsTest.java
+++ b/server/src/test/java/de/zalando/zally/RestApiViolationsTest.java
@@ -84,9 +84,6 @@ public class RestApiViolationsTest extends RestApiBaseTest {
         assertThat(rootObject.has("meter.api-reviews.requested.fifteenMinuteRate")).isTrue();
         assertThat(rootObject.has("meter.api-reviews.processed.fifteenMinuteRate")).isTrue();
         assertThat(rootObject.has("meter.api-reviews.violations.rule.checkapinameispresentrule.fifteenMinuteRate")).isTrue();
-        assertThat(rootObject.has("histogram.api-reviews.violations.count")).isTrue();
-        assertThat(rootObject.has("histogram.api-reviews.violations.type.must.count")).isTrue();
-        assertThat(rootObject.has("histogram.api-reviews.violations.rule.checkapinameispresentrule.count")).isTrue();
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/RestApiViolationsTest.java
+++ b/server/src/test/java/de/zalando/zally/RestApiViolationsTest.java
@@ -80,10 +80,10 @@ public class RestApiViolationsTest extends RestApiBaseTest {
 
         ResponseEntity<JsonNode> metricsResponse = restTemplate.getForEntity("http://localhost:" + managementPort + "/metrics", JsonNode.class);
         assertThat(metricsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-        System.out.println("JSON: " + metricsResponse.getBody().toString());
         JsonNode rootObject = metricsResponse.getBody();
-        assertThat(rootObject.has("counter.api-reviews.requested")).isTrue();
-        assertThat(rootObject.has("counter.api-reviews.processed")).isTrue();
+        assertThat(rootObject.has("meter.api-reviews.requested.fifteenMinuteRate")).isTrue();
+        assertThat(rootObject.has("meter.api-reviews.processed.fifteenMinuteRate")).isTrue();
+        assertThat(rootObject.has("meter.api-reviews.violations.rule.checkapinameispresentrule.fifteenMinuteRate")).isTrue();
         assertThat(rootObject.has("histogram.api-reviews.violations.count")).isTrue();
         assertThat(rootObject.has("histogram.api-reviews.violations.type.must.count")).isTrue();
         assertThat(rootObject.has("histogram.api-reviews.violations.rule.checkapinameispresentrule.count")).isTrue();


### PR DESCRIPTION
Fixes #314.

Example output of the metrics' endpoint:
```
{
   "meter.api-reviews.processed.fiveMinuteRate" : 0.6,
   "processors" : 4,
   "zmon.response.200.POST.api-violations.fifteenMinuteRate" : 0.6,
   "heap.used" : 265218,
   "zmon.response.200.POST.api-violations.oneMinuteRate" : 0.6,
   "meter.api-reviews.violations.type.COULD.oneMinuteRate" : 0.6,
   "meter.api-reviews.processed.oneMinuteRate" : 0.6,
   "httpsessions.max" : -1,
   "meter.api-reviews.violations.rule.nestedpathscouldberootpathsrule.meanRate" : 0.531373167528945,
   "meter.api-reviews.violations.rule.nestedpathscouldberootpathsrule.count" : 3,
   "httpsessions.active" : 0,
   "zmon.response.200.POST.api-violations.snapshot.999thPercentile" : 1133,
   "meter.api-reviews.violations.rule.use429headerforratelimitrule.count" : 3,
   "meter.api-reviews.violations.rule.useproblemjsonrule.count" : 3,
   "threads.daemon" : 21,
   "threads.peak" : 24,
   "meter.api-reviews.violations.type.COULD.count" : 3,
   "heap" : 4502016,
   "meter.api-reviews.violations.rule.useproblemjsonrule.oneMinuteRate" : 0.6,
   "meter.api-reviews.violations.rule.use429headerforratelimitrule.oneMinuteRate" : 0.6,
   "meter.api-reviews.violations.type.COULD.meanRate" : 0.531395313275535,
   "meter.api-reviews.violations.rule.use429headerforratelimitrule.meanRate" : 0.531360970155629,
   "meter.api-reviews.violations.type.MUST.count" : 6,
   "meter.api-reviews.requested.meanRate" : 0.465666983920202,
   "zmon.response.200.POST.api-violations.snapshot.mean" : 403,
   "threads.totalStarted" : 29,
   "instance.uptime" : 60702,
   "classes.unloaded" : 0,
   "zmon.response.200.POST.api-violations.meanRate" : 0.561400128131982,
   "classes" : 9035,
   "meter.api-reviews.violations.type.SHOULD.fiveMinuteRate" : 0.6,
   "meter.api-reviews.violations.rule.nestedpathscouldberootpathsrule.oneMinuteRate" : 0.6,
   "uptime" : 65660,
   "zmon.response.200.POST.api-violations.snapshot.95thPercentile" : 1133,
   "counter.status.200.api-violations" : 3,
   "meter.api-reviews.violations.rule.useproblemjsonrule.fiveMinuteRate" : 0.6,
   "meter.api-reviews.violations.rule.mediatypesrule.fiveMinuteRate" : 0.6,
   "mem.free" : 332285,
   "meter.api-reviews.violations.type.COULD.fiveMinuteRate" : 0.6,
   "meter.api-reviews.processed.meanRate" : 0.531412848206894,
   "meter.api-reviews.requested.fifteenMinuteRate" : 0.6,
   "nonheap.committed" : 68080,
   "gauge.response.api-violations" : 48,
   "nonheap.init" : 2496,
   "meter.api-reviews.violations.type.MUST.fiveMinuteRate" : 1.2,
   "zmon.response.200.POST.api-violations.snapshot.75thPercentile" : 1133,
   "nonheap" : 0,
   "zmon.response.200.POST.api-violations.snapshot.99thPercentile" : 1133,
   "heap.init" : 317440,
   "meter.api-reviews.violations.type.MUST.meanRate" : 1.06269810588946,
   "systemload.average" : 0.44,
   "meter.api-reviews.violations.rule.nestedpathscouldberootpathsrule.fifteenMinuteRate" : 0.6,
   "meter.api-reviews.violations.rule.use429headerforratelimitrule.fiveMinuteRate" : 0.6,
   "meter.api-reviews.violations.rule.useproblemjsonrule.fifteenMinuteRate" : 0.6,
   "meter.api-reviews.violations.type.SHOULD.meanRate" : 0.531380263078001,
   "zmon.response.200.POST.api-violations.snapshot.median" : 56,
   "meter.api-reviews.violations.rule.useproblemjsonrule.meanRate" : 0.531369193095302,
   "zmon.response.200.POST.api-violations.snapshot.stdDev" : 506,
   "threads" : 23,
   "meter.api-reviews.requested.fiveMinuteRate" : 0.6,
   "meter.api-reviews.violations.rule.mediatypesrule.fifteenMinuteRate" : 0.6,
   "meter.api-reviews.violations.type.SHOULD.fifteenMinuteRate" : 0.6,
   "meter.api-reviews.violations.rule.mediatypesrule.meanRate" : 0.53138623864711,
   "gc.ps_marksweep.time" : 107,
   "meter.api-reviews.violations.type.SHOULD.oneMinuteRate" : 0.6,
   "classes.loaded" : 9035,
   "gc.ps_scavenge.time" : 85,
   "meter.api-reviews.violations.rule.nestedpathscouldberootpathsrule.fiveMinuteRate" : 0.6,
   "heap.committed" : 597504,
   "zmon.response.200.POST.api-violations.snapshot.min" : 47,
   "meter.api-reviews.violations.rule.use429headerforratelimitrule.fifteenMinuteRate" : 0.6,
   "meter.api-reviews.violations.rule.mediatypesrule.count" : 3,
   "gc.ps_marksweep.count" : 2,
   "meter.api-reviews.violations.rule.mediatypesrule.oneMinuteRate" : 0.6,
   "meter.api-reviews.requested.count" : 3,
   "meter.api-reviews.violations.type.MUST.fifteenMinuteRate" : 1.2,
   "meter.api-reviews.requested.oneMinuteRate" : 0.6,
   "meter.api-reviews.violations.type.COULD.fifteenMinuteRate" : 0.6,
   "zmon.response.200.POST.api-violations.count" : 3,
   "nonheap.used" : 66475,
   "zmon.response.200.POST.api-violations.fiveMinuteRate" : 0.6,
   "zmon.response.200.POST.api-violations.snapshot.max" : 1133,
   "zmon.response.200.POST.api-violations.snapshot.98thPercentile" : 1133,
   "meter.api-reviews.violations.type.MUST.oneMinuteRate" : 1.2,
   "meter.api-reviews.violations.type.SHOULD.count" : 3,
   "gc.ps_scavenge.count" : 6,
   "meter.api-reviews.processed.count" : 3,
   "mem" : 663978,
   "meter.api-reviews.processed.fifteenMinuteRate" : 0.6
}
```