### PR TITLE
299: Use ViolationType Enum Instead of String Values

### DIFF
--- a/cli/src/main/java/de/zalando/zally/cli/Linter.java
+++ b/cli/src/main/java/de/zalando/zally/cli/Linter.java
@@ -9,16 +9,12 @@ import de.zalando.zally.cli.domain.ViolationsCount;
 import de.zalando.zally.cli.exception.CliException;
 import de.zalando.zally.cli.exception.CliExceptionType;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 
 public class Linter {
-    public static final List<String> violationTypes = Arrays.asList("must", "should", "could", "hint");
-
     private final ZallyApiClient client;
     private final ResultPrinter printer;
-    private final String mustViolationType = "must";
 
     public Linter(ZallyApiClient client, ResultPrinter printer) {
         this.client = client;
@@ -38,7 +34,7 @@ public class Linter {
             if (ViolationType.MUST.equals(violationType)) {
                 hasMustViolations = violations.isEmpty();
             }
-            printViolations(violations, violationType.name());
+            printViolations(violations, violationType);
         }
 
         printSummary(response.getCounters());
@@ -58,7 +54,9 @@ public class Linter {
         }
     }
 
-    private void printViolations(final List<Violation> violations, final String violationType) throws CliException {
+    private void printViolations(
+            final List<Violation> violations, final ViolationType violationType) throws CliException {
+
         try {
             printer.printViolations(violations, violationType);
         }  catch (IOException exception) {
@@ -68,7 +66,7 @@ public class Linter {
 
     private void printSummary(final ViolationsCount counters) throws CliException {
         try {
-            printer.printSummary(violationTypes, counters);
+            printer.printSummary(counters);
         } catch (IOException exception) {
             throw new CliException(CliExceptionType.CLI, "Cannot print violations summary:", exception.getMessage());
         }

--- a/cli/src/main/java/de/zalando/zally/cli/Linter.java
+++ b/cli/src/main/java/de/zalando/zally/cli/Linter.java
@@ -4,6 +4,7 @@ import de.zalando.zally.cli.api.RequestWrapperStrategy;
 import de.zalando.zally.cli.api.ViolationsApiResponse;
 import de.zalando.zally.cli.api.ZallyApiClient;
 import de.zalando.zally.cli.domain.Violation;
+import de.zalando.zally.cli.domain.ViolationType;
 import de.zalando.zally.cli.domain.ViolationsCount;
 import de.zalando.zally.cli.exception.CliException;
 import de.zalando.zally.cli.exception.CliExceptionType;
@@ -32,12 +33,12 @@ public class Linter {
 
 
         boolean hasMustViolations = false;
-        for (String violationType : violationTypes) {
+        for (ViolationType violationType : ViolationType.values()) {
             List<Violation> violations = violationsFilter.getViolations(violationType);
-            if (mustViolationType.equals(violationType)) {
+            if (ViolationType.MUST.equals(violationType)) {
                 hasMustViolations = violations.isEmpty();
             }
-            printViolations(violations, violationType);
+            printViolations(violations, violationType.name());
         }
 
         printSummary(response.getCounters());

--- a/cli/src/main/java/de/zalando/zally/cli/ResultPrinter.java
+++ b/cli/src/main/java/de/zalando/zally/cli/ResultPrinter.java
@@ -2,6 +2,7 @@ package de.zalando.zally.cli;
 
 import de.zalando.zally.cli.domain.Rule;
 import de.zalando.zally.cli.domain.Violation;
+import de.zalando.zally.cli.domain.ViolationType;
 import de.zalando.zally.cli.domain.ViolationsCount;
 
 import java.io.IOException;
@@ -39,12 +40,10 @@ public class ResultPrinter {
         }
     }
 
-    public void printViolations(List<Violation> violations, String violationType) throws IOException {
+    public void printViolations(List<Violation> violations, ViolationType violationType) throws IOException {
         if (!violations.isEmpty()) {
-
-            String normalizedViolationType = violationType.toUpperCase();
-            String header = String.format("Found the following %s violations", normalizedViolationType);
-            String headerColor = getHeaderColor(normalizedViolationType);
+            String header = String.format("Found the following %s violations", violationType.name());
+            String headerColor = getHeaderColor(violationType);
 
             printHeader(headerColor, header);
 
@@ -65,10 +64,11 @@ public class ResultPrinter {
         writer.flush();
     }
 
-    public void printSummary(List<String> violationTypeNames, ViolationsCount counters) throws IOException {
+    public void printSummary(ViolationsCount counters) throws IOException {
         printHeader(ANSI_CYAN, "Summary:");
-        for (String name : violationTypeNames) {
-            writer.write(name.toUpperCase() + " violations: " + counters.get(name) + "\n");
+        for (ViolationType violationType : ViolationType.values()) {
+            String name = violationType.name();
+            writer.write(name + " violations: " + counters.get(name.toLowerCase()) + "\n");
         }
         writer.flush();
     }
@@ -116,15 +116,15 @@ public class ResultPrinter {
         return sb.toString();
     }
 
-    private String getHeaderColor(String violationType) {
+    private String getHeaderColor(ViolationType violationType) {
         switch (violationType) {
-            case "MUST":
+            case MUST:
                 return ANSI_RED;
-            case "SHOULD":
+            case SHOULD:
                 return ANSI_YELLOW;
-            case "COULD":
+            case COULD:
                 return ANSI_GREEN;
-            case "HINT":
+            case HINT:
                 return ANSI_CYAN;
             default:
                 return ANSI_CYAN;

--- a/cli/src/main/java/de/zalando/zally/cli/ViolationsFilter.java
+++ b/cli/src/main/java/de/zalando/zally/cli/ViolationsFilter.java
@@ -14,10 +14,10 @@ public class ViolationsFilter {
         this.violations = violations;
     }
 
-    public List<Violation> getViolations(String violationType) {
+    public List<Violation> getViolations(ViolationType violationType) {
         return violations
                 .stream()
-                .filter(v -> v.getViolationType().equals(ViolationType.valueOf(violationType.toUpperCase())))
+                .filter(v -> v.getViolationType().equals(violationType))
                 .collect(Collectors.toList());
     }
 }

--- a/cli/src/main/java/de/zalando/zally/cli/ViolationsFilter.java
+++ b/cli/src/main/java/de/zalando/zally/cli/ViolationsFilter.java
@@ -1,6 +1,7 @@
 package de.zalando.zally.cli;
 
 import de.zalando.zally.cli.domain.Violation;
+import de.zalando.zally.cli.domain.ViolationType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,7 +17,7 @@ public class ViolationsFilter {
     public List<Violation> getViolations(String violationType) {
         return violations
                 .stream()
-                .filter(v -> v.getViolationType().equalsIgnoreCase(violationType))
+                .filter(v -> v.getViolationType().equals(ViolationType.valueOf(violationType.toUpperCase())))
                 .collect(Collectors.toList());
     }
 }

--- a/cli/src/main/java/de/zalando/zally/cli/domain/Violation.java
+++ b/cli/src/main/java/de/zalando/zally/cli/domain/Violation.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
 public class Violation {
     private String title;
     private String description;
-    private String violationType;
+    private ViolationType violationType;
     private String ruleLink;
     private List<String> paths = new ArrayList<>();
 
@@ -23,7 +23,7 @@ public class Violation {
     public Violation(JSONObject violationJson) {
         this.title = violationJson.getString("title");
         this.description = violationJson.getString("description");
-        this.violationType = violationJson.getString("violation_type");
+        this.violationType = ViolationType.valueOf(violationJson.getString("violation_type").toUpperCase());
 
         if (violationJson.has("rule_link")) {
             this.ruleLink = violationJson.getString("rule_link");
@@ -43,7 +43,7 @@ public class Violation {
         return description;
     }
 
-    public String getViolationType() {
+    public ViolationType getViolationType() {
         return violationType;
     }
 
@@ -63,7 +63,7 @@ public class Violation {
         this.description = description;
     }
 
-    public void setViolationType(String violationType) {
+    public void setViolationType(ViolationType violationType) {
         this.violationType = violationType;
     }
 

--- a/cli/src/main/java/de/zalando/zally/cli/domain/ViolationType.java
+++ b/cli/src/main/java/de/zalando/zally/cli/domain/ViolationType.java
@@ -1,0 +1,8 @@
+package de.zalando.zally.cli.domain;
+
+public enum ViolationType {
+    MUST,
+    SHOULD,
+    COULD,
+    HINT
+}

--- a/cli/src/test/java/de/zalando/zally/cli/LinterTest.java
+++ b/cli/src/test/java/de/zalando/zally/cli/LinterTest.java
@@ -68,9 +68,9 @@ public class LinterTest {
     @Test
     public void returnsTrueWhenOnlyShouldAndCouldViolationFound() throws Exception {
         final JSONArray violations = new JSONArray();
-        violations.put(getViolation("should", "should"));
-        violations.put(getViolation("could", "could"));
-        violations.put(getViolation("hint", "hint"));
+        violations.put(getViolation("SHOULD", "SHOULD"));
+        violations.put(getViolation("COULD", "COULD"));
+        violations.put(getViolation("HINT", "HINT"));
         final JSONObject testResult = getTestResult(violations);
 
         Boolean result = makeLinterCall(testResult);
@@ -84,9 +84,9 @@ public class LinterTest {
         assertEquals(1, shouldList.size());
         assertEquals(1, couldList.size());
         assertEquals(1, hintList.size());
-        assertEquals("should", shouldList.get(0).getTitle());
-        assertEquals("could", couldList.get(0).getTitle());
-        assertEquals("hint", hintList.get(0).getTitle());
+        assertEquals("SHOULD", shouldList.get(0).getTitle());
+        assertEquals("COULD", couldList.get(0).getTitle());
+        assertEquals("HINT", hintList.get(0).getTitle());
     }
 
     @Test
@@ -141,10 +141,10 @@ public class LinterTest {
         final Boolean result = linter.lint(getUrlWrapperStrategy());
 
         Mockito.verify(resultPrinter, Mockito.times(1)).printSummary(eq(linter.violationTypes), any());
-        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(mustListCaptor.capture(), eq("must"));
-        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(shouldListCaptor.capture(), eq("should"));
-        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(couldListCaptor.capture(), eq("could"));
-        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(hintListCaptor.capture(), eq("hint"));
+        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(mustListCaptor.capture(), eq("MUST"));
+        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(shouldListCaptor.capture(), eq("SHOULD"));
+        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(couldListCaptor.capture(), eq("COULD"));
+        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(hintListCaptor.capture(), eq("HINT"));
 
         return result;
     }

--- a/cli/src/test/java/de/zalando/zally/cli/LinterTest.java
+++ b/cli/src/test/java/de/zalando/zally/cli/LinterTest.java
@@ -7,11 +7,13 @@ import static org.mockito.ArgumentMatchers.eq;
 
 import de.zalando.zally.cli.api.RequestWrapperStrategy;
 import de.zalando.zally.cli.api.UrlWrapperStrategy;
-import de.zalando.zally.cli.api.ZallyApiClient;
 import de.zalando.zally.cli.api.ViolationsApiResponse;
+import de.zalando.zally.cli.api.ZallyApiClient;
 import de.zalando.zally.cli.domain.Violation;
+import de.zalando.zally.cli.domain.ViolationType;
 import java.io.IOException;
 import java.util.List;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -140,11 +142,26 @@ public class LinterTest {
         linter = new Linter(client, resultPrinter);
         final Boolean result = linter.lint(getUrlWrapperStrategy());
 
-        Mockito.verify(resultPrinter, Mockito.times(1)).printSummary(eq(linter.violationTypes), any());
-        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(mustListCaptor.capture(), eq("MUST"));
-        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(shouldListCaptor.capture(), eq("SHOULD"));
-        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(couldListCaptor.capture(), eq("COULD"));
-        Mockito.verify(resultPrinter, Mockito.times(1)).printViolations(hintListCaptor.capture(), eq("HINT"));
+        Mockito.verify(
+                resultPrinter,
+                Mockito.times(1)).printSummary(any()
+        );
+        Mockito.verify(
+                resultPrinter,
+                Mockito.times(1)).printViolations(mustListCaptor.capture(), eq(ViolationType.MUST)
+        );
+        Mockito.verify(
+                resultPrinter,
+                Mockito.times(1)).printViolations(shouldListCaptor.capture(), eq(ViolationType.SHOULD)
+        );
+        Mockito.verify(
+                resultPrinter,
+                Mockito.times(1)).printViolations(couldListCaptor.capture(), eq(ViolationType.COULD)
+        );
+        Mockito.verify(
+                resultPrinter,
+                Mockito.times(1)).printViolations(hintListCaptor.capture(), eq(ViolationType.HINT)
+        );
 
         return result;
     }

--- a/cli/src/test/java/de/zalando/zally/cli/ResultPrinterTest.java
+++ b/cli/src/test/java/de/zalando/zally/cli/ResultPrinterTest.java
@@ -24,7 +24,7 @@ public class ResultPrinterTest {
     public void testNoViolationsCase() throws IOException {
         ResultPrinter violationPrinter = new ResultPrinter(outStream);
         List<Violation> violations = new ArrayList<>();
-        violationPrinter.printViolations(violations, "must");
+        violationPrinter.printViolations(violations, ViolationType.MUST);
 
         assertEquals("", outContent.toString());
     }
@@ -47,7 +47,7 @@ public class ResultPrinterTest {
         violations.add(violationTwo);
 
         ResultPrinter violationPrinter = new ResultPrinter(outStream);
-        violationPrinter.printViolations(violations, "must");
+        violationPrinter.printViolations(violations, ViolationType.MUST);
 
         String expectedResult =  violationPrinter.ANSI_RED + "\nFound the following MUST violations\n"
                 + "===================================\n\n" + violationPrinter.ANSI_RESET
@@ -69,7 +69,7 @@ public class ResultPrinterTest {
         counters.put("hint", 15);
 
         final ResultPrinter resultPrinter = new ResultPrinter(outStream);
-        resultPrinter.printSummary(Linter.violationTypes, new ViolationsCount(counters));
+        resultPrinter.printSummary(new ViolationsCount(counters));
 
         String expectedResult = resultPrinter.ANSI_CYAN + "\nSummary:\n"
                 + "========\n\n" + resultPrinter.ANSI_RESET

--- a/cli/src/test/java/de/zalando/zally/cli/ResultPrinterTest.java
+++ b/cli/src/test/java/de/zalando/zally/cli/ResultPrinterTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import de.zalando.zally.cli.domain.Rule;
 import de.zalando.zally.cli.domain.Violation;
+import de.zalando.zally.cli.domain.ViolationType;
 import de.zalando.zally.cli.domain.ViolationsCount;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -34,11 +35,11 @@ public class ResultPrinterTest {
         paths.add("Violation 1 Path");
 
         final Violation violationOne = new Violation("Violation 1", "Violation 1 Description");
-        violationOne.setViolationType("MUST");
+        violationOne.setViolationType(ViolationType.MUST);
         violationOne.setPaths(paths);
 
         final Violation violationTwo = new Violation("Violation 2", "Violation 2 Description");
-        violationTwo.setViolationType("MUST");
+        violationTwo.setViolationType(ViolationType.MUST);
 
 
         final List<Violation> violations = new ArrayList<>();

--- a/cli/src/test/java/de/zalando/zally/cli/ViolationsFilterTest.java
+++ b/cli/src/test/java/de/zalando/zally/cli/ViolationsFilterTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import de.zalando.zally.cli.domain.Violation;
 import java.util.ArrayList;
 import java.util.List;
+
+import de.zalando.zally.cli.domain.ViolationType;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -64,10 +66,9 @@ public class ViolationsFilterTest {
     }
 
     private List<Violation> getFixtureViolations() {
-        final String[] violationTypes = new String[] { "MUST", "SHOULD", "COULD", "HINT" };
         final List<Violation> result = new ArrayList<>();
 
-        for (String violationType : violationTypes) {
+        for (ViolationType violationType : ViolationType.values()) {
             Violation violation = new Violation("Test " + violationType, "Test " + violationType + " description");
             violation.setViolationType(violationType);
             result.add(violation);

--- a/cli/src/test/java/de/zalando/zally/cli/ViolationsFilterTest.java
+++ b/cli/src/test/java/de/zalando/zally/cli/ViolationsFilterTest.java
@@ -3,10 +3,9 @@ package de.zalando.zally.cli;
 import static org.junit.Assert.assertEquals;
 
 import de.zalando.zally.cli.domain.Violation;
+import de.zalando.zally.cli.domain.ViolationType;
 import java.util.ArrayList;
 import java.util.List;
-
-import de.zalando.zally.cli.domain.ViolationType;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -23,7 +22,7 @@ public class ViolationsFilterTest {
 
         ViolationsFilter violationsFilter = new ViolationsFilter(fixtures);
 
-        List<Violation> result = violationsFilter.getViolations("MUST");
+        List<Violation> result = violationsFilter.getViolations(ViolationType.MUST);
         assertEquals(1, result.size());
         assertEquals(mustViolation, result.get(0));
     }
@@ -35,7 +34,7 @@ public class ViolationsFilterTest {
 
         ViolationsFilter violationsFilter = new ViolationsFilter(fixtures);
 
-        List<Violation> result = violationsFilter.getViolations("SHOULD");
+        List<Violation> result = violationsFilter.getViolations(ViolationType.SHOULD);
         assertEquals(1, result.size());
         assertEquals(shouldViolation, result.get(0));
     }
@@ -47,7 +46,7 @@ public class ViolationsFilterTest {
 
         ViolationsFilter violationsFilter = new ViolationsFilter(fixtures);
 
-        List<Violation> result = violationsFilter.getViolations("COULD");
+        List<Violation> result = violationsFilter.getViolations(ViolationType.COULD);
         assertEquals(1, result.size());
         assertEquals(couldViolations, result.get(0));
     }
@@ -60,7 +59,7 @@ public class ViolationsFilterTest {
 
         ViolationsFilter violationsFilter = new ViolationsFilter(fixtures);
 
-        List<Violation> result = violationsFilter.getViolations("HINT");
+        List<Violation> result = violationsFilter.getViolations(ViolationType.HINT);
         assertEquals(1, result.size());
         assertEquals(hintViolations, result.get(0));
     }

--- a/cli/src/test/java/de/zalando/zally/cli/domain/ViolationTest.java
+++ b/cli/src/test/java/de/zalando/zally/cli/domain/ViolationTest.java
@@ -20,7 +20,7 @@ public class ViolationTest {
 
         assertEquals("Test", violation.getTitle());
         assertEquals("Test Description", violation.getDescription());
-        assertEquals("MUST", violation.getViolationType());
+        assertEquals(ViolationType.MUST, violation.getViolationType());
         assertEquals("http://example.com", violation.getRuleLink());
         assertEquals(expectedRules, violation.getPaths());
     }
@@ -36,7 +36,7 @@ public class ViolationTest {
 
         assertEquals("Test", violation.getTitle());
         assertEquals("Test Description", violation.getDescription());
-        assertEquals("MUST", violation.getViolationType());
+        assertEquals(ViolationType.MUST, violation.getViolationType());
         assertNull(violation.getRuleLink());
         assertEquals(new ArrayList<>(), violation.getPaths());
     }


### PR DESCRIPTION
Clean up for #299 

Reason: it's really tricky to maintain hardcoded values, might be easier to use Enums instead. 