### PR TITLE
server: add cors support for /support-rules endpoint

### DIFF
--- a/server/src/main/java/de/zalando/zally/SupportedRulesController.java
+++ b/server/src/main/java/de/zalando/zally/SupportedRulesController.java
@@ -13,10 +13,12 @@ import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.CrossOrigin;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@CrossOrigin
 @RestController("/supported_rules")
 public class SupportedRulesController {
 

--- a/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.java
+++ b/server/src/main/java/de/zalando/zally/configuration/OAuthConfiguration.java
@@ -46,6 +46,7 @@ class OAuthConfiguration extends ResourceServerConfigurerAdapter {
                 .antMatchers("/health").permitAll()
                 .antMatchers("/metrics").access("#oauth2.hasScope('uid')")
                 .antMatchers("/api-violations").access("#oauth2.hasScope('uid')")
+                .antMatchers("/supported-rules").access("#oauth2.hasScope('uid')")
                 .antMatchers("**").denyAll();
 
         http


### PR DESCRIPTION
server: add cors support for /support-rules endpoint and add OAuth Configuration (without the access it's always denied - 403)

This to allow zally-web-ui integration without a proxy.

@fmueller does it make sense to have CORS support globally instead of per route basis?