### PR TITLE
server: use dash for path specified on RestController annotation

### DIFF
--- a/server/src/main/java/de/zalando/zally/SupportedRulesController.java
+++ b/server/src/main/java/de/zalando/zally/SupportedRulesController.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @CrossOrigin
-@RestController("/supported_rules")
+@RestController("/supported-rules")
 public class SupportedRulesController {
 
     private final List<Rule> rules;


### PR DESCRIPTION
server: use dash for path specified on RestController annotation