### PR TITLE
353 Temporary disable Golang test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,9 @@ script:
   - cp -R cli-go $ZALLY_GO_PATH
   - cd $ZALLY_GO_PATH/cli-go/zally
   - go get -t
-  - go test -v -cover ./...
+  
+  # TODO: Enable tests once switch to Go 1.8
+  # - go test -v -cover ./...
 
 after_success:
   - java -cp ~/codacy-coverage-reporter.jar com.codacy.CodacyCoverageReporter --language Java --coverageReport cli/build/reports/jacoco/test/jacocoTestReport.xml -t $CODACY_PROJECT_TOKEN


### PR DESCRIPTION
Tests will be enabled once Travis will be using Go 1.8

Related to #353 