### PR TITLE
Adding generation type for JPA entites

### DIFF
--- a/server/src/main/java/de/zalando/zally/apireview/ApiReview.java
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiReview.java
@@ -12,6 +12,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import java.io.Serializable;
@@ -28,7 +29,7 @@ import java.util.stream.Collectors;
 public class ApiReview implements Serializable {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/server/src/main/java/de/zalando/zally/apireview/RuleViolation.java
+++ b/server/src/main/java/de/zalando/zally/apireview/RuleViolation.java
@@ -8,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import java.io.Serializable;
@@ -16,7 +17,7 @@ import java.io.Serializable;
 public class RuleViolation implements Serializable {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @JsonIgnore


### PR DESCRIPTION
Right now, Zally server cannot use real Postgres database due to missing generation type for the JPA resources. This PR fixes this. 

Required for https://github.bus.zalan.do/team-architecture/management/issues/1