### PR TITLE
Change Review Statistics Endpoint

### DIFF
--- a/server/src/main/java/de/zalando/zally/statistic/ReviewStatistics.java
+++ b/server/src/main/java/de/zalando/zally/statistic/ReviewStatistics.java
@@ -11,12 +11,13 @@ public class ReviewStatistics {
 
     private int totalReviews;
     private int successfulReviews;
+    private int numberOfEndpoints;
     private int mustViolations;
     private int shouldViolations;
     private int mayViolations;
     private int hintViolations;
-    private List<ApiReviewStatistic> reviews;
     private List<ViolationStatistic> violations;
+    private List<ApiReviewStatistic> reviews;
 
     ReviewStatistics() {
     }
@@ -27,20 +28,21 @@ public class ReviewStatistics {
             .map(apiReview -> apiReview.isSuccessfulProcessed() ? 1 : 0)
             .mapToInt(Integer::intValue)
             .sum();
+        numberOfEndpoints = apiReviews.stream().mapToInt(ApiReview::getNumberOfEndpoints).sum();
         mustViolations = apiReviews.stream().mapToInt(ApiReview::getMustViolations).sum();
         shouldViolations = apiReviews.stream().mapToInt(ApiReview::getShouldViolations).sum();
         mayViolations = apiReviews.stream().mapToInt(ApiReview::getMayViolations).sum();
         hintViolations = apiReviews.stream().mapToInt(ApiReview::getHintViolations).sum();
-        reviews = apiReviews.stream().map(ApiReviewStatistic::new).collect(Collectors.toList());
         violations = apiReviews.stream()
             .flatMap(r -> r.getRuleViolations().stream())
-            .collect(Collectors.groupingBy(RuleViolation::getName, Collectors.toList()))
+            .collect(Collectors.groupingBy(RuleViolation::getName))
             .entrySet().stream()
             .filter(entry -> !entry.getValue().isEmpty())
             .map(entry ->
                 new ViolationStatistic(entry.getValue().get(0),
                     entry.getValue().stream().mapToInt(RuleViolation::getOccurrence).sum()))
             .collect(Collectors.toList());
+        reviews = apiReviews.stream().map(ApiReviewStatistic::new).collect(Collectors.toList());
     }
 
     public int getTotalReviews() {
@@ -57,6 +59,14 @@ public class ReviewStatistics {
 
     public void setSuccessfulReviews(int successfulReviews) {
         this.successfulReviews = successfulReviews;
+    }
+
+    public int getNumberOfEndpoints() {
+        return numberOfEndpoints;
+    }
+
+    public void setNumberOfEndpoints(int numberOfEndpoints) {
+        this.numberOfEndpoints = numberOfEndpoints;
     }
 
     public int getMustViolations() {
@@ -91,19 +101,19 @@ public class ReviewStatistics {
         this.hintViolations = hintViolations;
     }
 
-    public List<ApiReviewStatistic> getReviews() {
-        return reviews;
-    }
-
-    public void setReviews(List<ApiReviewStatistic> reviews) {
-        this.reviews = reviews;
-    }
-
     public List<ViolationStatistic> getViolations() {
         return violations;
     }
 
     public void setViolations(List<ViolationStatistic> violations) {
         this.violations = violations;
+    }
+
+    public List<ApiReviewStatistic> getReviews() {
+        return reviews;
+    }
+
+    public void setReviews(List<ApiReviewStatistic> reviews) {
+        this.reviews = reviews;
     }
 }

--- a/server/src/main/resources/api/zally-api.yaml
+++ b/server/src/main/resources/api/zally-api.yaml
@@ -212,12 +212,13 @@ definitions:
     required:
       - total_reviews
       - successful_reviews
+      - number_of_endpoints
       - must_violations
       - should_violations
       - may_violations
       - hint_violations
-      - reviews
       - violations
+      - reviews
     properties:
       total_reviews:
         type: number
@@ -225,6 +226,9 @@ definitions:
       successful_reviews:
         type: number
         example: 17
+      number_of_endpoints:
+        type: number
+        example: 10
       must_violations:
         type: number
         example: 123
@@ -237,14 +241,14 @@ definitions:
       hint_violations:
         type: number
         example: 5
-      reviews:
-        type: array
-        items:
-          $ref: '#/definitions/ReviewStatistic'
       violations:
         type: array
         items:
           $ref: '#/definitions/ViolationStatistic'
+      reviews:
+        type: array
+        items:
+          $ref: '#/definitions/ReviewStatistic'
 
   ReviewStatistic:
     type: object

--- a/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.java
+++ b/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.java
@@ -46,6 +46,13 @@ public class RestReviewStatisticsTest extends RestApiBaseTest {
     }
 
     @Test
+    public void shouldPutViolationsListBeforeReviewsList() {
+        ResponseEntity<String> response = restTemplate.getForEntity(getUrl(), String.class);
+
+        assertThat(response.getBody().indexOf("\"violations\":")).isLessThan(response.getBody().indexOf("\"reviews\":"));
+    }
+
+    @Test
     public void shouldReturnAllReviewStatisticsFromLastWeekIfNoIntervalParametersAreSupplied() {
         LocalDate from = TestDateUtil.now().minusDays(7L).toLocalDate();
 
@@ -70,6 +77,7 @@ public class RestReviewStatisticsTest extends RestApiBaseTest {
         ResponseEntity<ReviewStatistics> response = restTemplate.getForEntity(
             getUrl() + "?from=" + from.toString(), ReviewStatistics.class);
 
+        assertThat(response.getBody().getNumberOfEndpoints()).isEqualTo(reviews.size() * 2);
         assertThat(response.getBody().getMustViolations()).isEqualTo(reviews.size());
         assertThat(response.getBody().getTotalReviews()).isEqualTo(reviews.size());
         assertThat(response.getBody().getSuccessfulReviews()).isEqualTo(reviews.size());
@@ -125,6 +133,7 @@ public class RestReviewStatisticsTest extends RestApiBaseTest {
             ApiReview review = new ApiReview(emptyJsonPayload, "dummyApiDefinition", createRandomViolations());
             review.setDay(currentDate);
             review.setName("My API");
+            review.setNumberOfEndpoints(2);
 
             reviews.add(review);
             currentDate = currentDate.plusDays(1L);


### PR DESCRIPTION
Closes #391

As discussed, we do not rename fields as this would mean to duplicate the fields for API backward compatibility.

This PR: changes the order of violations and reviews list in statistics endpoint payload and adds aggregation of number of endpoints.