### PR TITLE
401: Release Go CLI

### DIFF
--- a/cli-go/.gitignore
+++ b/cli-go/.gitignore
@@ -1,0 +1,1 @@
+zally/dist

--- a/cli-go/README.md
+++ b/cli-go/README.md
@@ -32,3 +32,44 @@ Not feature-complete, in active development
     cd $GOPATH/github.com/zalando-incubator/zally/cli-go/zally
     go build
     ```
+
+## Release it
+
+1. Install `goreleaser` tool:
+
+    ```bash
+    go get -v github.com/goreleaser/goreleaser
+    cd $GOPATH/src/github.com/goreleaser/goreleaser
+    go install
+    ```
+
+    Alternatively you can download a latest release from [goreleaser Releases Page](https://github.com/goreleaser/goreleaser/releases)
+
+1. Clean up folder `cli-go/zally/dist` if exists
+
+1. Make sure that the repository state is clean:
+
+    ```bash
+    git status
+    ```
+
+1. Tag the release:
+
+    ```bash
+    git tag v1.1.0
+    ```
+
+1. Run `goreleaser`:
+
+    ```bash
+    cd cli-go/zally
+    goreleaser --skip-publish v1.1.0
+    ```
+
+1. Check builds inside `cli-go/zally/dist` directory.
+
+1. Publish release tag to GitHub:
+
+    ```bash
+    git push origin v1.1.0
+    ```

--- a/cli-go/zally/.goreleaser.yml
+++ b/cli-go/zally/.goreleaser.yml
@@ -1,0 +1,8 @@
+builds:
+  - binary: zally
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64

--- a/cli-go/zally/.goreleaser.yml
+++ b/cli-go/zally/.goreleaser.yml
@@ -6,3 +6,9 @@ builds:
       - linux
     goarch:
       - amd64
+
+archive:
+  format: tar.gz
+  replacements:
+    amd64: 64bit
+    darwin: macOS


### PR DESCRIPTION
Closes #401 

Contains release preparation instructions

**Proposal**: Let's keep release process manual for next release to feel it and then we can automate it using `goreleaser` tool. 

### How to test:
- Follow instructions in README.md from this PR