### PR TITLE
cli-go: cli: Used alternative validation approach in Bats tests #108

### DIFF
--- a/cli-go/integration_tests/tests.bats
+++ b/cli-go/integration_tests/tests.bats
@@ -3,53 +3,49 @@
 @test "CLI displays usage when no parameters specified" {
 	run cli-go/zally/zally
 	[ "$status" -eq 0 ]
-	[ "${lines[2]}" = "USAGE:" ]
-	[ "${lines[3]}" = "   zally [global options] command [command options] [arguments...]" ]
+	[[ "$output" =~ "USAGE:" ]]
+	[[ "$output" =~ "   zally [global options] command [command options] [arguments...]" ]]
 }
 
 @test "CLI works with local .yaml file" {
 	run cli-go/zally/zally lint server/src/test/resources/fixtures/api_spa.yaml
 	[ "$status" -eq 1 ]
-	[ "${lines[46]}" = "MUST violations: 6" ]
-	[ "${lines[47]}" = "SHOULD violations: 2" ]
-	[ "${lines[48]}" = "MAY violations: 0" ]
-	[ "${lines[49]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 51 ]
+	[[ "$output" =~ "MUST violations: 6" ]]
+	[[ "$output" =~ "SHOULD violations: 2" ]]
+	[[ "$output" =~ "MAY violations: 0" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 }
 
 @test "CLI works with local .json file" {
 	run cli-go/zally/zally lint server/src/test/resources/fixtures/api_spp.json
 	[ "$status" -eq 1 ]
-	[ "${lines[59]}" = "MUST violations: 2" ]
-	[ "${lines[60]}" = "SHOULD violations: 2" ]
-	[ "${lines[61]}" = "MAY violations: 1" ]
-	[ "${lines[62]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 64 ]
+	[[ "$output" =~ "MUST violations: 2" ]]
+	[[ "$output" =~ "SHOULD violations: 2" ]]
+	[[ "$output" =~ "MAY violations: 1" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 }
 
 @test "CLI works with remote .yaml file" {
 	run cli-go/zally/zally lint https://raw.githubusercontent.com/zalando-incubator/zally/e542a2d6e8f7f37f4adf2242343e453961537a08/server/src/test/resources/api_spa.yaml
 	[ "$status" -eq 1 ]
-	[ "${lines[46]}" = "MUST violations: 6" ]
-	[ "${lines[47]}" = "SHOULD violations: 2" ]
-	[ "${lines[48]}" = "MAY violations: 0" ]
-	[ "${lines[49]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 51 ]
+	[[ "$output" =~ "MUST violations: 6" ]]
+	[[ "$output" =~ "SHOULD violations: 2" ]]
+	[[ "$output" =~ "MAY violations: 0" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 }
 
 @test "CLI works with remote .json file" {
 	run cli-go/zally/zally lint https://raw.githubusercontent.com/zalando-incubator/zally/e542a2d6e8f7f37f4adf2242343e453961537a08/server/src/test/resources/api_spp.json
 	[ "$status" -eq 1 ]
-	[ "${lines[59]}" = "MUST violations: 2" ]
-	[ "${lines[60]}" = "SHOULD violations: 2" ]
-	[ "${lines[61]}" = "MAY violations: 1" ]
-	[ "${lines[62]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 64 ]
+	[[ "$output" =~ "MUST violations: 2" ]]
+	[[ "$output" =~ "SHOULD violations: 2" ]]
+	[[ "$output" =~ "MAY violations: 1" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 }
 
 @test "CLI should fail when any MUST violations" {
 	run cli-go/zally/zally lint server/src/test/resources/fixtures/api_spp.json
-	[ "${lines[63]}" = "Failing because: 2 must violation(s) found" ]
+	[[ "$output" =~ "Failing because: 2 must violation(s) found" ]]
 	[ "$status" -eq 1 ]
 }
 
@@ -61,17 +57,16 @@
 @test "CLI should validate zally API definition" {
 	run cli-go/zally/zally lint server/src/main/resources/api/zally-api.yaml
 	[ "$status" -eq 0 ]
-	[ "${lines[2]}" = "[33mSHOULD[0m [33mUse Specific HTTP Status Codes[0m" ]
-	[ "${lines[10]}" = "MUST violations: 0" ]
-	[ "${lines[11]}" = "SHOULD violations: 1" ]
-	[ "${lines[12]}" = "MAY violations: 0" ]
-	[ "${lines[13]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 14 ]
+	[[ "$output" =~ "[33mSHOULD[0m [33mUse Specific HTTP Status Codes[0m" ]]
+	[[ "$output" =~ "MUST violations: 0" ]]
+	[[ "$output" =~ "SHOULD violations: 1" ]]
+	[[ "$output" =~ "MAY violations: 0" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 }
 
 @test "Displays rule list" {
 	run cli-go/zally/zally rules
 	[ "$status" -eq 0 ]
-	[ "${lines[0]}" = "[31mM001[0m [31mMUST[0m: Avoid Link in Header Rule" ]
-	[ "${lines[1]}" = "	http://zalando.github.io/restful-api-guidelines/hyper-media/Hypermedia.html#must-do-not-use-link-headers-with-json-entities" ]
+	[[ "$output" =~ "[31mM001[0m [31mMUST[0m: Avoid Link in Header Rule" ]]
+	[[ "$output" =~ "	http://zalando.github.io/restful-api-guidelines/hyper-media/Hypermedia.html#must-do-not-use-link-headers-with-json-entities" ]]
 }

--- a/cli/integration_tests/tests.bats
+++ b/cli/integration_tests/tests.bats
@@ -3,67 +3,62 @@
 @test "CLI requires filename or URL to be specified" {
 	run cli/bin/zally
 	[ "$status" -eq 1 ]
-	[ "${lines[0]}" = "Please provide a swagger file path or URL" ]
-	[ "${lines[1]}" = "Validates the given swagger specification using Zally service" ]
+	[[ "$output" =~ "Please provide a swagger file path or URL" ]]
+	[[ "$output" =~ "Validates the given swagger specification using Zally service" ]]
 }
 
 @test "CLI works with local .yaml file" {
 	run cli/bin/zally -l http://localhost:8080 server/src/test/resources/fixtures/api_spa.yaml
 	[ "$status" -eq 1 ]
-	[ "${lines[57]}" = "[0mMUST violations: 6" ]
-	[ "${lines[58]}" = "SHOULD violations: 2" ]
-	[ "${lines[59]}" = "MAY violations: 0" ]
-	[ "${lines[60]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 61 ]
+	[[ "$output" =~ "[0mMUST violations: 6" ]]
+	[[ "$output" =~ "SHOULD violations: 2" ]]
+	[[ "$output" =~ "MAY violations: 0" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 }
 
 @test "CLI works with local .json file" {
 	run cli/bin/zally -l http://localhost:8080 server/src/test/resources/fixtures/api_spp.json
 	[ "$status" -eq 1 ]
-	[ "${lines[68]}" = "[0mMUST violations: 2" ]
-	[ "${lines[69]}" = "SHOULD violations: 2" ]
-	[ "${lines[70]}" = "MAY violations: 1" ]
-	[ "${lines[71]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 72 ]
+	[[ "$output" =~ "[0mMUST violations: 2" ]]
+	[[ "$output" =~ "SHOULD violations: 2" ]]
+	[[ "$output" =~ "MAY violations: 1" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 }
 
 @test "CLI works with remote .yaml file" {
 	run cli/bin/zally -l http://localhost:8080 https://raw.githubusercontent.com/zalando-incubator/zally/e542a2d6e8f7f37f4adf2242343e453961537a08/server/src/test/resources/api_spa.yaml
 	[ "$status" -eq 1 ]
-	[ "${lines[57]}" = "[0mMUST violations: 6" ]
-	[ "${lines[58]}" = "SHOULD violations: 2" ]
-	[ "${lines[59]}" = "MAY violations: 0" ]
-	[ "${lines[60]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 61 ]
+	[[ "$output" =~ "[0mMUST violations: 6" ]]
+	[[ "$output" =~ "SHOULD violations: 2" ]]
+	[[ "$output" =~ "MAY violations: 0" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 }
 
 @test "CLI works with remote .json file" {
 	run cli/bin/zally -l http://localhost:8080 https://raw.githubusercontent.com/zalando-incubator/zally/e542a2d6e8f7f37f4adf2242343e453961537a08/server/src/test/resources/api_spp.json
 	[ "$status" -eq 1 ]
-	[ "${lines[68]}" = "[0mMUST violations: 2" ]
-	[ "${lines[69]}" = "SHOULD violations: 2" ]
-	[ "${lines[70]}" = "MAY violations: 1" ]
-	[ "${lines[71]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 72 ]
+	[[ "$output" =~ "[0mMUST violations: 2" ]]
+	[[ "$output" =~ "SHOULD violations: 2" ]]
+	[[ "$output" =~ "MAY violations: 1" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 }
 
 @test "Displays rule list" {
 	run cli/bin/zally -l http://localhost:8080 -r
 	[ "$status" -eq 0 ]
-	[ "${lines[1]}" = "Supported Rules" ]
-	[ "${lines[2]}" = "===============" ]
-	[ "${lines[3]}" = "[0m[31mS001[0m SHOULD Avoid reserved Javascript keywords" ]
-	[ "${lines[5]}" = "[32mM001[0m MUST Avoid Link in Header Rule" ]
+	[[ "$output" =~ "Supported Rules" ]]
+	[[ "$output" =~ "===============" ]]
+	[[ "$output" =~ "[0m[31mS001[0m SHOULD Avoid reserved Javascript keywords" ]]
+	[[ "$output" =~ "[32mM001[0m MUST Avoid Link in Header Rule" ]]
 }
 
 @test "CLI 1.0 works with recent API" {
 	run curl -sL https://github.com/zalando-incubator/zally/releases/download/v1.0.0/zally-1.0.0.jar -o zally-1.0.0.jar
 	run java -jar zally-1.0.0.jar -l http://localhost:8080 https://raw.githubusercontent.com/zalando-incubator/zally/e542a2d6e8f7f37f4adf2242343e453961537a08/server/src/test/resources/api_spp.json
 	[ "$status" -eq 1 ]
-	[ "${lines[60]}" = "[0mMUST violations: 2" ]
-	[ "${lines[61]}" = "SHOULD violations: 2" ]
-	[ "${lines[62]}" = "COULD violations: 0" ]
-	[ "${lines[63]}" = "HINT violations: 0" ]
-	[ "${#lines[@]}" -eq 64 ]
+	[[ "$output" =~ "[0mMUST violations: 2" ]]
+	[[ "$output" =~ "SHOULD violations: 2" ]]
+	[[ "$output" =~ "COULD violations: 0" ]]
+	[[ "$output" =~ "HINT violations: 0" ]]
 	run rm zally-1.0.0.jar
 }


### PR DESCRIPTION
I've already had my first "Bats hurt" =) so please consider this testing approach. It uses slightly relaxed condition - checks that the substring appears anywhere in the output. I believe it is strong enough but still can save us some time.
Another possible solution: use relative line numbers, e.g. from the end of the file

       [ "${lines[${#lines[@]}-1]}" = "HINT violations: 1" ]
        [ "${#lines[@]}" -eq 71 ]