### PR TITLE
server: UseProblemJsonRule rule should not NPE on specs w/o definitions #182

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/UseProblemJsonRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/UseProblemJsonRule.kt
@@ -44,7 +44,7 @@ class UseProblemJsonRule : SwaggerRule() {
     private fun isProblemJson(swagger: Swagger, response: Response): Boolean {
         val schema = response.schema
         val properties = when (schema) {
-            is RefProperty -> getProperties(swagger, swagger.definitions[(response.schema as RefProperty).simpleRef])
+            is RefProperty -> getProperties(swagger, swagger.definitions?.get((response.schema as RefProperty).simpleRef))
             is ObjectProperty -> schema.properties?.keys.orEmpty()
             else -> emptySet<String>()
         }

--- a/server/src/test/java/de/zalando/zally/rule/UseProblemJsonRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/UseProblemJsonRuleTest.kt
@@ -126,4 +126,15 @@ class UseProblemJsonRuleTest {
             "/request-groups/{request_group_id}/updates GET 429"
         ))
     }
+
+    @Test
+    fun shouldNotThrowExOnSchemasWithReferencesToEmptyDefinitions() {
+        val swagger = getFixture("missing_definitions.yaml")
+        val result = UseProblemJsonRule().validate(swagger)!!
+        assertThat(result.paths).hasSameElementsAs(listOf(
+                "/identifier-types/{identifier_type}/source-ids/{source_identifier} GET 401",
+                "/identifier-types/{identifier_type}/source-ids/{source_identifier} GET 403",
+                "/identifier-types/{identifier_type}/source-ids/{source_identifier} GET 404"
+        ))
+    }
 }

--- a/server/src/test/resources/fixtures/missing_definitions.yaml
+++ b/server/src/test/resources/fixtures/missing_definitions.yaml
@@ -1,0 +1,58 @@
+swagger: '2.0'
+info:
+  title: Product Service
+  version: 1.0.0
+
+parameters:
+  identifier_type:
+    name: identifier_type
+    description: Specifies the type of the customer identifier.
+    in: path
+    type: string
+    x-extensible-enum:
+      - customer_hash
+      - cookie_id
+      - fullvisitorid
+      - client_id
+      - idfa
+    required: true
+
+  target_identifier_type:
+    name: identifier_type
+    description: Specifies what type of customer identifiers to be returned
+    in: query
+    type: string
+    x-extensible-enum:
+      - customer_hash
+      - cookie_id
+      - fullvisitorid
+      - client_id
+      - idfa
+    required: false
+
+paths:
+  /identifier-types/{identifier_type}/source-ids/{source_identifier}:
+    get:
+      tags:
+        - id-mappings
+      description: List of identifiers associated with the source id.
+      parameters:
+        - $ref: '#/parameters/identifier_type'
+        - $ref: '#/parameters/source_identifier'
+        - $ref: '#/parameters/target_identifier_type'
+      responses:
+        200:
+          description: The identifiers associated with the source id.
+          schema:
+            $ref: '#/definitions/IdMappingResults'
+        401:
+          description: User is not authenticated
+        403:
+          description: User is not authorized
+        404:
+          description: Identifier is not found
+          schema:
+            $ref: '#definitions/Problem'
+      security:
+        - oauth2:
+          - 'cross-device-graph-service.read'


### PR DESCRIPTION
Spotted that on specs with references to /definitions ( $ref: '#/definitions/IdMappingResults') UseProblemJsonRule throws NPE if the /definitions section is absent or empty.

This spec is incorrect, ofc, and this situation is not covered by any of existing rules, including schema validation. So additionally we can consider implementing Reference-check rule, someth like Swagger editor does: 

 
>Resolver error at paths./identifier-types/{identifier_type}/source-ids/{source_identifier}.get.responses.200.schema.$ref
>Could not resolve reference: #/definitions/IdMappingResults
>Jump to line 47