### PR TITLE
server: implement api parameter to ignore rules by code (#406)

### DIFF
--- a/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.java
+++ b/server/src/main/java/de/zalando/zally/apireview/ApiViolationsController.java
@@ -53,8 +53,8 @@ public class ApiViolationsController {
     public ApiDefinitionResponse validate(@RequestBody ApiDefinitionRequest request) {
         metricServices.increment("meter.api-reviews.requested");
 
-        final String apiDefinition = retrieveApiDefinition(request);
-        final List<Violation> violations = rulesValidator.validate(apiDefinition);
+        String apiDefinition = retrieveApiDefinition(request);
+        List<Violation> violations = rulesValidator.validate(apiDefinition, request.getIgnoreRules());
         apiReviewRepository.save(new ApiReview(request, apiDefinition, violations));
 
         ApiDefinitionResponse response = buildApiDefinitionResponse(violations);

--- a/server/src/main/java/de/zalando/zally/dto/ApiDefinitionRequest.kt
+++ b/server/src/main/java/de/zalando/zally/dto/ApiDefinitionRequest.kt
@@ -10,7 +10,9 @@ data class ApiDefinitionRequest (
     @JsonDeserialize(using = JsonRawValueDeserializer::class)
     var apiDefinition: String? = null,
 
-    var apiDefinitionUrl: String? = null
+    var apiDefinitionUrl: String? = null,
+
+    var ignoreRules: List<String>? = emptyList()
 ) {
     /** for java invocations: it doesn't have overloaded constructors */
     companion object Factory {

--- a/server/src/main/java/de/zalando/zally/rule/ApiValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ApiValidator.kt
@@ -1,5 +1,5 @@
 package de.zalando.zally.rule
 
 interface ApiValidator {
-    fun validate(swaggerContent: String): List<Violation>
+    fun validate(swaggerContent: String, ignoreRules: List<String> = emptyList()): List<Violation>
 }

--- a/server/src/main/java/de/zalando/zally/rule/CompositeRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/CompositeRulesValidator.kt
@@ -8,7 +8,7 @@ class CompositeRulesValidator(
         @Autowired val swaggerRulesValidator: SwaggerRulesValidator,
         @Autowired val jsonRulesValidator: JsonRulesValidator) : ApiValidator {
 
-    override fun validate(swaggerContent: String): List<Violation> =
-            swaggerRulesValidator.validate(swaggerContent) + jsonRulesValidator.validate(swaggerContent)
+    override fun validate(swaggerContent: String, ignoreRules: List<String>): List<Violation> =
+            swaggerRulesValidator.validate(swaggerContent, ignoreRules) + jsonRulesValidator.validate(swaggerContent, ignoreRules)
 
 }

--- a/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
@@ -2,14 +2,15 @@ package de.zalando.zally.rule
 
 abstract class RulesValidator<RuleT>(val rules: List<RuleT>, val rulesPolicy: RulesPolicy, val invalidApiRule: InvalidApiSchemaRule) : ApiValidator where RuleT : Rule {
 
-    override fun validate(swaggerContent: String): List<Violation> {
+    final override fun validate(swaggerContent: String, ignoreRules: List<String>): List<Violation> {
         val ruleChecker = try {
             createRuleChecker(swaggerContent)
         } catch (e: Exception) {
             return listOf(invalidApiRule.getGeneralViolation())
         }
         return rules
-                .filter { rule -> rulesPolicy.accepts(rule) }
+                .filter { it.code !in ignoreRules }
+                .filter { rulesPolicy.accepts(it) }
                 .flatMap(ruleChecker)
                 .sortedBy(Violation::violationType)
     }

--- a/server/src/main/resources/api/zally-api.yaml
+++ b/server/src/main/resources/api/zally-api.yaml
@@ -179,6 +179,10 @@ definitions:
         type: object
       api_definition_url:
         type: string
+      ignoreRules:
+        type: array
+        items:
+          type: string
 
   LintingResponse:
     type: object

--- a/server/src/test/java/de/zalando/zally/apireview/ApiDefinitionReaderTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiDefinitionReaderTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.web.client.RestTemplate;
 
+import static java.util.Collections.emptyList;
 import static net.jadler.Jadler.closeJadler;
 import static net.jadler.Jadler.initJadlerUsing;
 import static org.junit.Assert.assertEquals;
@@ -39,7 +40,7 @@ public class ApiDefinitionReaderTest {
 
     @Test
     public void shouldReturnStringWhenApiDefinitionIsFound() {
-        ApiDefinitionRequest request = new ApiDefinitionRequest(contentInJson, "http://zalando.de");
+        ApiDefinitionRequest request = new ApiDefinitionRequest(contentInJson, "http://zalando.de", emptyList());
         String result = reader.read(request);
         assertEquals(contentInJson, result);
     }

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -84,6 +85,17 @@ public class RestApiViolationsTest extends RestApiBaseTest {
     @Test
     public void shouldIgnoreRulesWithVendorExtension() throws IOException {
         ApiDefinitionResponse response = sendApiDefinition(readApiDefinition("fixtures/api_spp_ignored_rules.json"));
+
+        List<ViolationDTO> violations = response.getViolations();
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).getTitle()).isEqualTo("dummy2");
+    }
+
+    @Test
+    public void shouldIgnoreRulesWithApiParameter() throws IOException {
+        ApiDefinitionRequest request = readApiDefinition("fixtures/api_spp.json");
+        request.setIgnoreRules(Arrays.asList("M001", "M999"));
+        ApiDefinitionResponse response = sendApiDefinition(request);
 
         List<ViolationDTO> violations = response.getViolations();
         assertThat(violations).hasSize(1);


### PR DESCRIPTION
Closes #406

Example request:
```json
{
  "api_definition": {
    "never_gonna_give_you": "up!"
  },
  "ignore_rules": ["M001", "M999"]
}
```