### PR TITLE
419: Add @rbarilani to web-ui code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 
 # You can also use email addresses if you prefer. They'll be used to look up
 # users just like we do for commit author emails.
-# docs/*  docs@example.com
+web-ui  @rbarilani


### PR DESCRIPTION
Follow up on #419 

Since we have decided to merge `zally` and `zally-web-ui`, let's add @rbarilani to code owners of `web-ui` subproject. 