### PR TITLE
Imposed stable ordering on /supported-rules

### DIFF
--- a/server/src/main/java/de/zalando/zally/dto/ViolationType.java
+++ b/server/src/main/java/de/zalando/zally/dto/ViolationType.java
@@ -1,16 +1,20 @@
 package de.zalando.zally.dto;
 
 public enum ViolationType {
+    /*
+     * Violation Types must be ordered from most to least severe as the enum ordering is
+     * used to sort things elsewhere.
+     */
 
     MUST("must"),
     SHOULD("should"),
     MAY("may"),
-    HINT("hint"),
 
     /*
      * @deprecated Use MAY instead
      */
-    @Deprecated COULD("could");
+    @Deprecated() COULD("could"),
+    HINT("hint");
 
     private final String metricIdentifier;
 

--- a/server/src/main/java/de/zalando/zally/rule/SupportedRulesController.java
+++ b/server/src/main/java/de/zalando/zally/rule/SupportedRulesController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 
 @CrossOrigin
@@ -50,6 +51,9 @@ public class SupportedRulesController {
             .filter(r -> filterByIsActive(r, isActiveFilter))
             .filter(r -> filterByType(r, typeFilter))
             .map(this::toDto)
+            .sorted(comparing(RuleDTO::getType)
+                .thenComparing(RuleDTO::getCode)
+                .thenComparing(RuleDTO::getTitle))
             .collect(toList());
 
         return new RulesListDTO(filteredRules);

--- a/server/src/test/java/de/zalando/zally/dto/ViolationTypeTest.java
+++ b/server/src/test/java/de/zalando/zally/dto/ViolationTypeTest.java
@@ -1,0 +1,27 @@
+package de.zalando.zally.dto;
+
+import org.junit.Test;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static de.zalando.zally.dto.ViolationType.HINT;
+import static de.zalando.zally.dto.ViolationType.MUST;
+import static de.zalando.zally.dto.ViolationType.values;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class ViolationTypeTest {
+
+    private final SortedSet<ViolationType> sorted = new TreeSet<>(asList(values()));
+
+    @Test
+    public void mostSevere() {
+        assertEquals(MUST, sorted.first());
+    }
+
+    @Test
+    public void leastSevere() {
+        assertEquals(HINT, sorted.last());
+    }
+}

--- a/server/src/test/java/de/zalando/zally/rule/RestSupportedRulesTest.java
+++ b/server/src/test/java/de/zalando/zally/rule/RestSupportedRulesTest.java
@@ -14,7 +14,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @TestPropertySource(properties = "zally.ignoreRules=M001,C001")
@@ -31,6 +33,18 @@ public class RestSupportedRulesTest extends RestApiBaseTest {
     @Test
     public void testRulesCount() {
         assertThat(getSupportedRules().size()).isEqualTo(implementedRules.size());
+    }
+
+    @Test
+    public void testRulesOrdered() {
+        final List<RuleDTO> rules = getSupportedRules();
+        for(int i=1;i<rules.size();++i) {
+            final ViolationType prev = rules.get(i - 1).getType();
+            final ViolationType next = rules.get(i).getType();
+            assertTrue("Item #" + i + " is out of order:\n" +
+                    rules.stream().map(Object::toString).collect(joining("\n")),
+                    prev.compareTo(next)<=0);
+        }
     }
 
     @Test


### PR DESCRIPTION
... stable and predictable but not user configurable.