### PR TITLE
Only show active rules

### DIFF
--- a/cli/zally/commands/supported_rules.go
+++ b/cli/zally/commands/supported_rules.go
@@ -61,9 +61,9 @@ func validateType(ruleType string) error {
 }
 
 func fetchRules(requestBuilder *utils.RequestBuilder, rulesType string) (*domain.Rules, error) {
-	uri := "/supported-rules"
+	uri := "/supported-rules?is_active=true"
 	if rulesType != "" {
-		uri += "?type=" + rulesType
+		uri += "&type=" + rulesType
 	}
 	request, err := requestBuilder.Build("GET", uri, nil)
 	if err != nil {

--- a/cli/zally/commands/supported_rules_test.go
+++ b/cli/zally/commands/supported_rules_test.go
@@ -47,7 +47,7 @@ func TestListRules(t *testing.T) {
 
 		err := listRules(getSupportedRulesContext(testServer.URL, "must"))
 		expectedError := fmt.Sprintf(
-			"Get %s/supported-rules?type=must: net/http: request canceled"+
+			"Get %s/supported-rules?is_active=true&type=must: net/http: request canceled"+
 				" (Client.Timeout exceeded while awaiting headers)",
 			testServer.URL,
 		)
@@ -98,7 +98,7 @@ func TestFetchRules(t *testing.T) {
 			fixture, _ := ioutil.ReadFile("testdata/rules_response.json")
 			w.Header().Set("Content-Type", "application/json")
 			io.WriteString(w, string(fixture))
-			tests.AssertEquals(t, r.URL.RawQuery, "type=must")
+			tests.AssertEquals(t, r.URL.RawQuery, "is_active=true&type=must")
 		}
 		testServer := httptest.NewServer(http.HandlerFunc(handler))
 		defer testServer.Close()

--- a/web-ui/src/client/app/components/__tests__/rules.test.jsx
+++ b/web-ui/src/client/app/components/__tests__/rules.test.jsx
@@ -75,7 +75,6 @@ describe('Rule component', () => {
     expect(RuleLink.length).toEqual(1);
     expect(RuleLink.prop('url')).toEqual('someurl');
     expect(component.find('RuleType').length).toEqual(1);
-    expect(component.find('.dc--text-small').text()).toEqual('Active');
   });
 
   test('should render a rule without url', () => {
@@ -93,6 +92,5 @@ describe('Rule component', () => {
     expect(component.find('RuleType').length).toEqual(1);
     expect(RuleLink.length).toEqual(0);
     expect(component.find('RuleType').length).toEqual(1);
-    expect(component.find('.dc--text-small').text()).toEqual('Inactive');
   });
 });

--- a/web-ui/src/client/app/components/rules.jsx
+++ b/web-ui/src/client/app/components/rules.jsx
@@ -6,7 +6,6 @@ import { Msg } from './msg.jsx';
 export function RulesTab({ rules, error }) {
   return (
     <div>
-      <h3>SUPPORTED RULES</h3>
       {error ? <Msg type="error" title="ERROR" text={error} /> : null}
       <FluidContainer>
         <ul className="violations-content">
@@ -34,7 +33,6 @@ export function Rule(props) {
         {rule.type} {'\u2013'} {rule.title}
       </h4>
       {rule.url ? <RuleLink url={rule.url} /> : null}
-      <p className="dc--text-small">{rule.is_active ? 'Active' : 'Inactive'}</p>
     </li>
   );
 }

--- a/web-ui/src/client/app/containers/rules.jsx
+++ b/web-ui/src/client/app/containers/rules.jsx
@@ -88,31 +88,6 @@ export class Rules extends Component {
     return (
       <div>
         <div className="dc-row">
-          <div className="dc-column dc-column--small-12 dc-column--large-7">
-            <label className="dc-label filter-navigation__label">
-              Show only
-            </label>
-            <div className="dc-btn-group dc-btn-group--in-row">
-              <NavLink
-                to={{ pathname: '/rules', search: '?is_active=true' }}
-                className="dc-btn dc-btn--small dc-btn--in-btn-group"
-                activeClassName="dc-btn--primary"
-                isActive={this.sameFilter(true)}
-              >
-                Active
-              </NavLink>
-              <NavLink
-                to={{ pathname: '/rules', search: '?is_active=false' }}
-                className="dc-btn dc-btn--small dc-btn--in-btn-group"
-                activeClassName="dc-btn--primary"
-                isActive={this.sameFilter(false)}
-              >
-                Inactive
-              </NavLink>
-            </div>
-          </div>
-        </div>
-        <div className="dc-row">
           <div className="dc-column">
             <div className="dc-column__contents">
               <RulesTab error={this.state.error} rules={this.state.rules} />

--- a/web-ui/src/client/app/services/__tests__/rest.test.js
+++ b/web-ui/src/client/app/services/__tests__/rest.test.js
@@ -126,7 +126,9 @@ describe('RestService', () => {
 
     return RestService.getSupportedRules().then(rules => {
       expect(rules).toBe(mockRules);
-      expect(client.fetch).toHaveBeenCalledWith('/zally-api/supported-rules', {
+      expect(
+        client.fetch
+      ).toHaveBeenCalledWith('/zally-api/supported-rules?is_active=true', {
         method: 'GET',
         headers: {
           Accept: 'application/json',

--- a/web-ui/src/client/app/services/rest.js
+++ b/web-ui/src/client/app/services/rest.js
@@ -42,9 +42,7 @@ export const RestService = {
         'Content-Type': 'application/json',
       },
     };
-    const url =
-      `${window.env.ZALLY_API_URL}/supported-rules` +
-      this.objectToParams(params);
+    const url = `${window.env.ZALLY_API_URL}/supported-rules?is_active=true`;
     return client
       .fetch(url, options)
       .then(response => response.json())


### PR DESCRIPTION
Closes #566 

Modified cli to always request only the active rules, never displaying inactive ones.
Modified web-ui to always request on the active rules and never display the active vs inactive status any more.
Left the server capable of filtering on is_active=true|false in case it's useful to somebody. Although I guess if there's no use case we need to support then maybe we ought to remove that too and simplify the codebase.