### PR TITLE
Added RuleSet interface

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/AbstractRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/AbstractRule.kt
@@ -1,6 +1,8 @@
 package de.zalando.zally.rule
 
-abstract class AbstractRule : Rule {
+abstract class AbstractRule(ruleSet: RuleSet) : Rule {
+
+    override val ruleSet = ruleSet
 
     val zallyIgnoreExtension = "x-zally-ignore"
 

--- a/server/src/main/java/de/zalando/zally/rule/AvoidLinkHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/AvoidLinkHeadersRule.kt
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class AvoidLinkHeadersRule(@Autowired rulesConfig: Config) : HttpHeadersRule(rulesConfig) {
+class AvoidLinkHeadersRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : HttpHeadersRule(ruleSet, rulesConfig) {
     override val title = "Avoid Link in Header Rule"
     override val violationType = ViolationType.MUST
     override val url = "/#166"

--- a/server/src/main/java/de/zalando/zally/rule/AvoidSynonymsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/AvoidSynonymsRule.kt
@@ -9,8 +9,8 @@ import org.springframework.boot.actuate.metrics.dropwizard.DropwizardMetricServi
 import org.springframework.stereotype.Component
 
 @Component
-class AvoidSynonymsRule(
-    @Autowired rulesConfig: Config, @Autowired metricServices: DropwizardMetricServices) : SwaggerRule() {
+class AvoidSynonymsRule(@Autowired ruleSet: ZalandoRuleSet,
+    @Autowired rulesConfig: Config, @Autowired metricServices: DropwizardMetricServices) : SwaggerRule(ruleSet) {
 
     override val title = "Use common property names"
     override val url = "/#174"

--- a/server/src/main/java/de/zalando/zally/rule/AvoidTrailingSlashesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/AvoidTrailingSlashesRule.kt
@@ -3,10 +3,11 @@ package de.zalando.zally.rule
 import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.util.PatternUtil
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class AvoidTrailingSlashesRule : SwaggerRule() {
+class AvoidTrailingSlashesRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Avoid Trailing Slashes"
     override val url = "/#136"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/CommonFieldTypesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/CommonFieldTypesRule.kt
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class CommonFieldTypesRule(@Autowired rulesConfig: Config) : SwaggerRule() {
+class CommonFieldTypesRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : SwaggerRule(ruleSet) {
     override val title = "Use common field names"
     override val url = "/#174"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/DefineOAuthScopesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/DefineOAuthScopesRule.kt
@@ -5,10 +5,11 @@ import de.zalando.zally.dto.ViolationType.MUST
 import io.swagger.models.Operation
 import io.swagger.models.Swagger
 import io.swagger.models.auth.OAuth2Definition
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class DefineOAuthScopesRule : SwaggerRule() {
+class DefineOAuthScopesRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Define and Assign Access Rights (Scopes)"
     override val url = "/#104"
     override val violationType = MUST

--- a/server/src/main/java/de/zalando/zally/rule/EverySecondPathLevelParameterRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/EverySecondPathLevelParameterRule.kt
@@ -3,10 +3,11 @@ package de.zalando.zally.rule
 import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.util.PatternUtil.isPathVariable
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class EverySecondPathLevelParameterRule : SwaggerRule() {
+class EverySecondPathLevelParameterRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Every Second Path Level To Be Parameter"
     override val url = "/#143"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/ExtensibleEnumRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ExtensibleEnumRule.kt
@@ -17,10 +17,11 @@ import io.swagger.models.properties.LongProperty
 import io.swagger.models.properties.PasswordProperty
 import io.swagger.models.properties.Property
 import io.swagger.models.properties.StringProperty
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class ExtensibleEnumRule : SwaggerRule() {
+class ExtensibleEnumRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Prefer Compatible Extensions"
     override val url = "/#107"
     override val violationType = SHOULD

--- a/server/src/main/java/de/zalando/zally/rule/ExtractBasePathRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ExtractBasePathRule.kt
@@ -2,10 +2,11 @@ package de.zalando.zally.rule
 
 import de.zalando.zally.dto.ViolationType
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class ExtractBasePathRule : SwaggerRule() {
+class ExtractBasePathRule(@Autowired ruleSet: ZallyRuleSet) : SwaggerRule(ruleSet) {
 
     override val title = "Base path can be extracted"
     override val url = "/naming/Naming.html"

--- a/server/src/main/java/de/zalando/zally/rule/FormatForNumbersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/FormatForNumbersRule.kt
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class FormatForNumbersRule(@Autowired rulesConfig: Config) : SwaggerRule() {
+class FormatForNumbersRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : SwaggerRule(ruleSet) {
     override val title = "Define Format for Type Number and Integer"
     override val url = "/#171"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/HttpHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/HttpHeadersRule.kt
@@ -5,7 +5,7 @@ import io.swagger.models.Response
 import io.swagger.models.Swagger
 import io.swagger.models.parameters.Parameter
 
-abstract class HttpHeadersRule(rulesConfig: Config) : SwaggerRule() {
+abstract class HttpHeadersRule(ruleSet: ZalandoRuleSet, rulesConfig: Config) : SwaggerRule(ruleSet) {
 
     private val headersWhitelist = rulesConfig.getStringList(HttpHeadersRule::class.simpleName + ".whitelist").toSet()
 

--- a/server/src/main/java/de/zalando/zally/rule/HyphenateHttpHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/HyphenateHttpHeadersRule.kt
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class HyphenateHttpHeadersRule(@Autowired rulesConfig: Config) : HttpHeadersRule(rulesConfig) {
+class HyphenateHttpHeadersRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : HttpHeadersRule(ruleSet, rulesConfig) {
     override val title = "Use Hyphenated HTTP Headers"
     override val url = "/#131"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/InvalidApiSchemaRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/InvalidApiSchemaRule.kt
@@ -12,7 +12,7 @@ import java.io.IOException
 import java.net.URL
 
 @Component
-open class InvalidApiSchemaRule(@Autowired rulesConfig: Config) : JsonRule() {
+open class InvalidApiSchemaRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : JsonRule(ruleSet) {
 
     private val log = LoggerFactory.getLogger(InvalidApiSchemaRule::class.java)
 

--- a/server/src/main/java/de/zalando/zally/rule/JsonRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonRule.kt
@@ -1,8 +1,9 @@
 package de.zalando.zally.rule
 
 import com.fasterxml.jackson.databind.JsonNode
+import org.springframework.beans.factory.annotation.Autowired
 
-abstract class JsonRule : AbstractRule() {
+abstract class JsonRule(@Autowired ruleSet: RuleSet) : AbstractRule(ruleSet) {
 
     fun accepts(swagger: JsonNode): Boolean {
         val ignoredCodes = swagger.get(zallyIgnoreExtension)

--- a/server/src/main/java/de/zalando/zally/rule/KebabCaseInPathSegmentsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/KebabCaseInPathSegmentsRule.kt
@@ -3,10 +3,11 @@ package de.zalando.zally.rule
 import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.util.PatternUtil
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class KebabCaseInPathSegmentsRule : SwaggerRule() {
+class KebabCaseInPathSegmentsRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
 
     override val title = "Lowercase words with hyphens"
     override val url = "/#129"

--- a/server/src/main/java/de/zalando/zally/rule/LimitNumberOfResourcesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/LimitNumberOfResourcesRule.kt
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class LimitNumberOfResourcesRule(@Autowired rulesConfig: Config) : SwaggerRule() {
+class LimitNumberOfResourcesRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : SwaggerRule(ruleSet) {
     override val title = "Limit number of Resources"
     override val url = "/#146"
     override val violationType = ViolationType.SHOULD

--- a/server/src/main/java/de/zalando/zally/rule/LimitNumberOfSubresourcesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/LimitNumberOfSubresourcesRule.kt
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class LimitNumberOfSubresourcesRule(@Autowired rulesConfig: Config) : SwaggerRule() {
+class LimitNumberOfSubresourcesRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : SwaggerRule(ruleSet) {
     override val title = "Limit number of Sub-resources level"
     override val url = "/#147"
     override val violationType = ViolationType.SHOULD

--- a/server/src/main/java/de/zalando/zally/rule/MediaTypesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/MediaTypesRule.kt
@@ -4,10 +4,11 @@ import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.util.PatternUtil.isApplicationJsonOrProblemJson
 import de.zalando.zally.util.PatternUtil.isCustomMediaTypeWithVersioning
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class MediaTypesRule : SwaggerRule() {
+class MediaTypesRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
 
     override val title = "Prefer standard media type names"
     override val url = "/#172"

--- a/server/src/main/java/de/zalando/zally/rule/NestedPathsMayBeRootPathsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/NestedPathsMayBeRootPathsRule.kt
@@ -3,10 +3,11 @@ package de.zalando.zally.rule
 import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.util.PatternUtil.isPathVariable
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class NestedPathsMayBeRootPathsRule : SwaggerRule() {
+class NestedPathsMayBeRootPathsRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Consider Using (Non-) Nested URLs"
     override val url = "/#145"
     override val violationType = ViolationType.MAY

--- a/server/src/main/java/de/zalando/zally/rule/NoProtocolInHostRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/NoProtocolInHostRule.kt
@@ -2,10 +2,11 @@ package de.zalando.zally.rule
 
 import de.zalando.zally.dto.ViolationType
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class NoProtocolInHostRule : SwaggerRule() {
+class NoProtocolInHostRule(@Autowired ruleSet: ZallyRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Host should not contain protocol"
     // TODO: Provide URL
     override val url = ""

--- a/server/src/main/java/de/zalando/zally/rule/NoUnusedDefinitionsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/NoUnusedDefinitionsRule.kt
@@ -15,10 +15,11 @@ import io.swagger.models.properties.MapProperty
 import io.swagger.models.properties.ObjectProperty
 import io.swagger.models.properties.Property
 import io.swagger.models.properties.RefProperty
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class NoUnusedDefinitionsRule : SwaggerRule() {
+class NoUnusedDefinitionsRule(@Autowired ruleSet: ZallyRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Do not leave unused definitions"
     override val violationType = ViolationType.SHOULD
     // TODO: Provide URL

--- a/server/src/main/java/de/zalando/zally/rule/NoVersionInUriRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/NoVersionInUriRule.kt
@@ -3,10 +3,11 @@ package de.zalando.zally.rule
 import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.util.PatternUtil
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class NoVersionInUriRule : SwaggerRule() {
+class NoVersionInUriRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Do Not Use URI Versioning"
     override val url = "/#115"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/NotSpecifyStandardErrorCodesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/NotSpecifyStandardErrorCodesRule.kt
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class NotSpecifyStandardErrorCodesRule(@Autowired rulesConfig: Config) : SwaggerRule() {
+class NotSpecifyStandardErrorCodesRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : SwaggerRule(ruleSet) {
     override val title = "Not Specify Standard Error Codes"
     override val url = "/#151"
     override val violationType = ViolationType.HINT

--- a/server/src/main/java/de/zalando/zally/rule/PascalCaseHttpHeadersRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/PascalCaseHttpHeadersRule.kt
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class PascalCaseHttpHeadersRule(@Autowired rulesConfig: Config) : HttpHeadersRule(rulesConfig) {
+class PascalCaseHttpHeadersRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : HttpHeadersRule(ruleSet, rulesConfig) {
     override val title = "Prefer Hyphenated-Pascal-Case for HTTP header fields"
     override val url = "/#132"
     override val violationType = ViolationType.SHOULD

--- a/server/src/main/java/de/zalando/zally/rule/PluralizeNamesForArraysRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/PluralizeNamesForArraysRule.kt
@@ -4,10 +4,11 @@ import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.util.WordUtil.isPlural
 import de.zalando.zally.util.getAllJsonObjects
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class PluralizeNamesForArraysRule : SwaggerRule() {
+class PluralizeNamesForArraysRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Array names should be pluralized"
     override val url = "/#120"
     override val violationType = ViolationType.SHOULD

--- a/server/src/main/java/de/zalando/zally/rule/PluralizeResourceNamesRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/PluralizeResourceNamesRule.kt
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class PluralizeResourceNamesRule(@Autowired rulesConfig: Config) : SwaggerRule() {
+class PluralizeResourceNamesRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : SwaggerRule(ruleSet) {
     override val title = "Pluralize Resource Names"
     override val url = "/#134"
     override val violationType = ViolationType.SHOULD

--- a/server/src/main/java/de/zalando/zally/rule/QueryParameterCollectionFormatRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/QueryParameterCollectionFormatRule.kt
@@ -4,8 +4,9 @@ import de.zalando.zally.dto.ViolationType
 import io.swagger.models.Swagger
 import io.swagger.models.parameters.Parameter
 import io.swagger.models.parameters.QueryParameter
+import org.springframework.beans.factory.annotation.Autowired
 
-class QueryParameterCollectionFormatRule : SwaggerRule() {
+class QueryParameterCollectionFormatRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
 
     override val title = "Explicitly define the Collection Format of Query Parameters"
     override val url = "/#154"

--- a/server/src/main/java/de/zalando/zally/rule/Rule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/Rule.kt
@@ -4,6 +4,7 @@ import de.zalando.zally.dto.ViolationType
 
 interface Rule {
 
+    val ruleSet: RuleSet
     val title: String
     val violationType: ViolationType
     val url: String?

--- a/server/src/main/java/de/zalando/zally/rule/RuleSet.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RuleSet.kt
@@ -1,0 +1,7 @@
+package de.zalando.zally.rule
+
+interface RuleSet {
+    val id: String
+    val title: String
+    val url: String
+}

--- a/server/src/main/java/de/zalando/zally/rule/RuleSet.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RuleSet.kt
@@ -1,7 +1,20 @@
 package de.zalando.zally.rule
 
+import java.net.URI
+
+/**
+ * A logical grouping of rules that can be enabled and disabled as a whole.
+ * RuleSets can be used to represent a company's guidelines or to define
+ * finer grained logical groupings such as technical vs semantic rules.
+ */
 interface RuleSet {
+
+    /** A unique identifier for the RuleSet */
     val id: String
+
+    /** A user friendly heading for the RuleSet */
     val title: String
-    val url: String
+
+    /** The base url where documentation for this RuleSet can be found */
+    val url: URI
 }

--- a/server/src/main/java/de/zalando/zally/rule/SecureWithOAuth2Rule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SecureWithOAuth2Rule.kt
@@ -3,10 +3,11 @@ package de.zalando.zally.rule
 import de.zalando.zally.dto.ViolationType
 import io.swagger.models.Scheme
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class SecureWithOAuth2Rule : SwaggerRule() {
+class SecureWithOAuth2Rule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Secure Endpoints with OAuth 2.0"
     override val url = "/#104"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/SnakeCaseForQueryParamsRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SnakeCaseForQueryParamsRule.kt
@@ -4,13 +4,14 @@ import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.util.PatternUtil
 import io.swagger.models.Swagger
 import io.swagger.models.parameters.QueryParameter
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 /**
  * Lint for snake case for query params
  */
 @Component
-class SnakeCaseForQueryParamsRule : SwaggerRule() {
+class SnakeCaseForQueryParamsRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Use snake_case (never camelCase) for Query Parameters"
     override val url = "/#130"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/SnakeCaseInPropNameRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SnakeCaseInPropNameRule.kt
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class SnakeCaseInPropNameRule(@Autowired rulesConfig: Config) : SwaggerRule() {
+class SnakeCaseInPropNameRule(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : SwaggerRule(ruleSet) {
     override val title = "snake_case property names"
     override val url = "/#118"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/SuccessResponseAsJsonObjectRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SuccessResponseAsJsonObjectRule.kt
@@ -6,10 +6,11 @@ import io.swagger.models.ModelImpl
 import io.swagger.models.Swagger
 import io.swagger.models.properties.Property
 import io.swagger.models.properties.RefProperty
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class SuccessResponseAsJsonObjectRule : SwaggerRule() {
+class SuccessResponseAsJsonObjectRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
 
     override val title = "Response As JSON Object"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/SwaggerRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SwaggerRule.kt
@@ -2,7 +2,7 @@ package de.zalando.zally.rule
 
 import io.swagger.models.Swagger
 
-abstract class SwaggerRule : AbstractRule() {
+abstract class SwaggerRule(ruleSet: RuleSet) : AbstractRule(ruleSet) {
 
     fun accepts(swagger: Swagger): Boolean {
         val ignoredCodes = swagger.vendorExtensions?.get(zallyIgnoreExtension)

--- a/server/src/main/java/de/zalando/zally/rule/Use429HeaderForRateLimitRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/Use429HeaderForRateLimitRule.kt
@@ -3,10 +3,12 @@ package de.zalando.zally.rule
 import de.zalando.zally.dto.ViolationType
 import io.swagger.models.Swagger
 import io.swagger.models.properties.Property
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class Use429HeaderForRateLimitRule : SwaggerRule() {
+class Use429HeaderForRateLimitRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
+
     override val title = "Use 429 With Header For Rate Limits"
     override val url = "/#153"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/UsePasswordFlowWithOauth2Rule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/UsePasswordFlowWithOauth2Rule.kt
@@ -3,8 +3,9 @@ package de.zalando.zally.rule
 import de.zalando.zally.dto.ViolationType
 import io.swagger.models.Swagger
 import io.swagger.models.auth.OAuth2Definition
+import org.springframework.beans.factory.annotation.Autowired
 
-class UsePasswordFlowWithOauth2Rule : SwaggerRule() {
+class UsePasswordFlowWithOauth2Rule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Set Flow to Password When Using OAuth 2.0"
     override val url = "/#104"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/UseProblemJsonRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/UseProblemJsonRule.kt
@@ -10,10 +10,11 @@ import io.swagger.models.Response
 import io.swagger.models.Swagger
 import io.swagger.models.properties.ObjectProperty
 import io.swagger.models.properties.RefProperty
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class UseProblemJsonRule : SwaggerRule() {
+class UseProblemJsonRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Use Problem JSON"
     override val url = "/#176"
     override val violationType = ViolationType.MUST

--- a/server/src/main/java/de/zalando/zally/rule/UseSpecificHttpStatusCodes.kt
+++ b/server/src/main/java/de/zalando/zally/rule/UseSpecificHttpStatusCodes.kt
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class UseSpecificHttpStatusCodes(@Autowired rulesConfig: Config) : SwaggerRule() {
+class UseSpecificHttpStatusCodes(@Autowired ruleSet: ZalandoRuleSet, @Autowired rulesConfig: Config) : SwaggerRule(ruleSet) {
     override val title = "Use Specific HTTP Status Codes"
     override val url = "/#150"
 

--- a/server/src/main/java/de/zalando/zally/rule/VersionInInfoSectionRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/VersionInInfoSectionRule.kt
@@ -3,10 +3,11 @@ package de.zalando.zally.rule
 import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.util.PatternUtil.isVersion
 import io.swagger.models.Swagger
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class VersionInInfoSectionRule : SwaggerRule() {
+class VersionInInfoSectionRule(@Autowired ruleSet: ZalandoRuleSet) : SwaggerRule(ruleSet) {
     override val title = "Provide version information"
     override val url = "/#116"
     override val violationType = ViolationType.SHOULD

--- a/server/src/main/java/de/zalando/zally/rule/ZalandoRuleSet.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ZalandoRuleSet.kt
@@ -1,0 +1,10 @@
+package de.zalando.zally.rule
+
+import org.springframework.stereotype.Component
+
+@Component
+class ZalandoRuleSet : RuleSet {
+    override val id = javaClass.simpleName
+    override val title = "Zalando RESTful API and Event Scheme Guidelines"
+    override val url = "https://zalando.github.io/restful-api-guidelines/"
+}

--- a/server/src/main/java/de/zalando/zally/rule/ZalandoRuleSet.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ZalandoRuleSet.kt
@@ -1,10 +1,11 @@
 package de.zalando.zally.rule
 
 import org.springframework.stereotype.Component
+import java.net.URI
 
 @Component
 class ZalandoRuleSet : RuleSet {
     override val id = javaClass.simpleName
     override val title = "Zalando RESTful API and Event Scheme Guidelines"
-    override val url = "https://zalando.github.io/restful-api-guidelines/"
+    override val url = URI.create("https://zalando.github.io/restful-api-guidelines/")
 }

--- a/server/src/main/java/de/zalando/zally/rule/ZallyRuleSet.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ZallyRuleSet.kt
@@ -1,0 +1,10 @@
+package de.zalando.zally.rule
+
+import org.springframework.stereotype.Component
+
+@Component
+class ZallyRuleSet : RuleSet {
+    override val id = javaClass.simpleName
+    override val title = "Additional Zally Swagger Rules"
+    override val url = "https://github.com/zalando-incubator/zally"
+}

--- a/server/src/main/java/de/zalando/zally/rule/ZallyRuleSet.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ZallyRuleSet.kt
@@ -1,10 +1,11 @@
 package de.zalando.zally.rule
 
 import org.springframework.stereotype.Component
+import java.net.URI
 
 @Component
 class ZallyRuleSet : RuleSet {
     override val id = javaClass.simpleName
     override val title = "Additional Zally Swagger Rules"
-    override val url = "https://github.com/zalando-incubator/zally"
+    override val url = URI.create("https://github.com/zalando-incubator/zally")
 }

--- a/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/ApiReviewTest.java
@@ -3,6 +3,7 @@ package de.zalando.zally.apireview;
 import de.zalando.zally.dto.ApiDefinitionRequest;
 import de.zalando.zally.dto.ViolationType;
 import de.zalando.zally.rule.Rule;
+import de.zalando.zally.rule.RuleSet;
 import de.zalando.zally.rule.Violation;
 import de.zalando.zally.util.ResourceUtil;
 import org.jetbrains.annotations.NotNull;
@@ -18,6 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ApiReviewTest {
 
     private Rule dummyRule = new Rule() {
+
+        @NotNull
+        @Override
+        public RuleSet getRuleSet() {
+            return null;
+        }
 
         @NotNull
         @Override

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
@@ -7,11 +7,14 @@ import de.zalando.zally.rule.CompositeRulesValidator;
 import de.zalando.zally.rule.InvalidApiSchemaRule;
 import de.zalando.zally.rule.JsonRule;
 import de.zalando.zally.rule.JsonRulesValidator;
+import de.zalando.zally.rule.RuleSet;
 import de.zalando.zally.rule.RulesPolicy;
 import de.zalando.zally.rule.SwaggerRule;
 import de.zalando.zally.rule.SwaggerRulesValidator;
 import de.zalando.zally.rule.Violation;
+import de.zalando.zally.rule.ZalandoRuleSet;
 import io.swagger.models.Swagger;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,10 +44,14 @@ public class RestApiTestConfiguration {
         );
         return new CompositeRulesValidator(
                 new SwaggerRulesValidator(rules, rulesPolicy, invalidApiRule),
-                new JsonRulesValidator(Arrays.asList(new CheckApiNameIsPresentJsonRule()), rulesPolicy, invalidApiRule));
+                new JsonRulesValidator(Arrays.asList(new CheckApiNameIsPresentJsonRule(new ZalandoRuleSet())), rulesPolicy, invalidApiRule));
     }
 
-    private static  class CheckApiNameIsPresentJsonRule extends  JsonRule{
+    private static  class CheckApiNameIsPresentJsonRule extends JsonRule {
+
+        public CheckApiNameIsPresentJsonRule(@NotNull RuleSet ruleSet) {
+            super(ruleSet);
+        }
 
         @Override
         public Iterable<Violation> validate(final JsonNode swagger) {
@@ -88,6 +95,7 @@ public class RestApiTestConfiguration {
         private final String apiName;
 
         CheckApiNameIsPresentRule(String apiName) {
+            super(new ZalandoRuleSet());
             this.apiName = apiName;
         }
 
@@ -127,6 +135,10 @@ public class RestApiTestConfiguration {
     }
 
     private static class AlwaysGiveAHintRule extends SwaggerRule {
+        public AlwaysGiveAHintRule() {
+            super(new ZalandoRuleSet());
+        }
+
         @Override
         public Violation validate(Swagger swagger) {
             return new Violation(

--- a/server/src/test/java/de/zalando/zally/dto/ViolationsCounterTest.java
+++ b/server/src/test/java/de/zalando/zally/dto/ViolationsCounterTest.java
@@ -2,6 +2,7 @@ package de.zalando.zally.dto;
 
 import de.zalando.zally.rule.AvoidTrailingSlashesRule;
 import de.zalando.zally.rule.Violation;
+import de.zalando.zally.rule.ZalandoRuleSet;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -96,7 +97,7 @@ public class ViolationsCounterTest {
 
     private Violation generateViolation(ViolationType violationType) {
         return new Violation(
-            new AvoidTrailingSlashesRule(),
+            new AvoidTrailingSlashesRule(new ZalandoRuleSet()),
             "Test Name",
             "Test Description",
             violationType,

--- a/server/src/test/java/de/zalando/zally/rule/AvoidLinkHeadersRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/AvoidLinkHeadersRuleTest.kt
@@ -8,22 +8,24 @@ import org.junit.Test
 
 class AvoidLinkHeadersRuleTest {
 
+    private val rule = AvoidLinkHeadersRule(ZalandoRuleSet(), testConfig)
+
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(AvoidLinkHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseSpa() {
         val swagger = getFixture("api_spa.yaml")
-        assertThat(AvoidLinkHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCase() {
         val swagger = getFixture("avoidLinkHeaderRuleInvalid.json")
-        val violation = AvoidLinkHeadersRule(testConfig).validate(swagger)!!
+        val violation = rule.validate(swagger)!!
         assertThat(violation.violationType).isEqualTo(ViolationType.MUST)
         assertThat(violation.paths).hasSameElementsAs(
             listOf("/product-put-requests/{product_path} Link", "/products Link"))

--- a/server/src/test/java/de/zalando/zally/rule/AvoidSynonymsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/AvoidSynonymsRuleTest.kt
@@ -10,10 +10,12 @@ import org.junit.Test
 
 class AvoidSynonymsRuleTest {
 
+    private val rule = AvoidSynonymsRule(ZalandoRuleSet(), testConfig, testMetricServices)
+
     @Test
     fun positiveCase() {
         val swagger = swaggerWithDefinitions("ExampleDefinition" to listOf("customer_id", "some_unique_prop_name"))
-        assertThat(AvoidSynonymsRule(testConfig, testMetricServices).validate(swagger, true)).isNull()
+        assertThat(rule.validate(swagger, true)).isNull()
     }
 
     @Test
@@ -22,7 +24,7 @@ class AvoidSynonymsRuleTest {
             "Def1" to listOf("order_id", "c_id", "cust_id"),
             "Def2" to listOf("orderid", "c_id")
         )
-        val result = AvoidSynonymsRule(testConfig, testMetricServices).validate(swagger, true)!!
+        val result = rule.validate(swagger, true)!!
         println(result.description)
         assertThat(result.description).contains("c_id", "cust_id", "orderid")
         assertThat(result.paths).hasSameElementsAs(listOf(
@@ -40,12 +42,12 @@ class AvoidSynonymsRuleTest {
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(AvoidSynonymsRule(testConfig, testMetricServices).validate(swagger, true)).isNull()
+        assertThat(rule.validate(swagger, true)).isNull()
     }
 
     @Test
     fun positiveCaseSpa() {
         val swagger = getFixture("api_spa.yaml")
-        assertThat(AvoidSynonymsRule(testConfig, testMetricServices).validate(swagger, true)).isNull()
+        assertThat(rule.validate(swagger, true)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/AvoidTrailingSlashesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/AvoidTrailingSlashesRuleTest.kt
@@ -7,21 +7,23 @@ import org.junit.Test
 
 class AvoidTrailingSlashesRuleTest {
 
+    private val rule = AvoidTrailingSlashesRule(ZalandoRuleSet())
+
     @Test
     fun emptySwagger() {
-        assertThat(AvoidTrailingSlashesRule().validate(Swagger())).isNull()
+        assertThat(rule.validate(Swagger())).isNull()
     }
 
     @Test
     fun positiveCase() {
         val testAPI = swaggerWithPaths("/api/test-api")
-        assertThat(AvoidTrailingSlashesRule().validate(testAPI)).isNull()
+        assertThat(rule.validate(testAPI)).isNull()
     }
 
     @Test
     fun negativeCase() {
         val testAPI = swaggerWithPaths("/api/test-api/", "/api/test", "/some/other/path", "/long/bad/path/with/slash/")
-        assertThat(AvoidTrailingSlashesRule().validate(testAPI)!!.paths).hasSameElementsAs(
+        assertThat(rule.validate(testAPI)!!.paths).hasSameElementsAs(
             listOf("/api/test-api/", "/long/bad/path/with/slash/"))
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/CommonFieldTypesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/CommonFieldTypesRuleTest.kt
@@ -10,7 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class CommonFieldTypesRuleTest {
-    private val rule = CommonFieldTypesRule(testConfig)
+    private val rule = CommonFieldTypesRule(ZalandoRuleSet(), testConfig)
 
     object PropertyWithNullType : AbstractProperty() {
         override fun getType(): String? {

--- a/server/src/test/java/de/zalando/zally/rule/DefineOAuthScopesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/DefineOAuthScopesRuleTest.kt
@@ -7,38 +7,40 @@ import org.junit.Test
 
 class DefineOAuthScopesRuleTest {
 
+    private val rule = DefineOAuthScopesRule(ZalandoRuleSet())
+
     @Test
     fun emptyAPI() {
-        assertThat(DefineOAuthScopesRule().validate(Swagger())).isNull()
+        assertThat(rule.validate(Swagger())).isNull()
     }
 
     @Test
     fun apiWithoutScope() {
         val swagger = getFixture("api_without_scopes_defined.yaml")
-        assertThat(DefineOAuthScopesRule().validate(swagger)!!.paths).hasSize(4)
+        assertThat(rule.validate(swagger)!!.paths).hasSize(4)
     }
 
     @Test
     fun apiWithDefinedScope() {
         val swagger = getFixture("api_with_defined_scope.yaml")
-        assertThat(DefineOAuthScopesRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun apiWithUndefinedScope() {
         val swagger = getFixture("api_with_undefined_scope.yaml")
-        assertThat(DefineOAuthScopesRule().validate(swagger)!!.paths).hasSize(2)
+        assertThat(rule.validate(swagger)!!.paths).hasSize(2)
     }
 
     @Test
     fun apiWithDefinedAndUndefinedScope() {
         val swagger = getFixture("api_with_defined_and_undefined_scope.yaml")
-        assertThat(DefineOAuthScopesRule().validate(swagger)!!.paths).hasSize(2)
+        assertThat(rule.validate(swagger)!!.paths).hasSize(2)
     }
 
     @Test
     fun apiWithDefinedTopLevelScope() {
         val swagger = getFixture("api_with_toplevel_scope.yaml")
-        assertThat(DefineOAuthScopesRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/EverySecondPathLevelParameterRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/EverySecondPathLevelParameterRuleTest.kt
@@ -8,9 +8,10 @@ import org.junit.Test
 
 class EverySecondPathLevelParameterRuleTest {
 
+    private val rule = EverySecondPathLevelParameterRule(ZalandoRuleSet())
+
     @Test
     fun positiveCase() {
-        val rule = EverySecondPathLevelParameterRule()
         val swagger = swaggerWithPaths(
             "/some/{param-1}/path/",
             "/another/{param-1}/path/{param-2}/third",
@@ -21,7 +22,6 @@ class EverySecondPathLevelParameterRuleTest {
 
     @Test
     fun negativeCase() {
-        val rule = EverySecondPathLevelParameterRule()
         val swagger = swaggerWithPaths(
             "/api/some/{param-1}/path/",
             "/another/{param-0}/{param-1}",
@@ -39,14 +39,12 @@ class EverySecondPathLevelParameterRuleTest {
 
     @Test
     fun positiveCaseSpp() {
-        val rule = EverySecondPathLevelParameterRule()
         val swagger = getFixture("api_spp.json")
         assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCaseSpa() {
-        val rule = EverySecondPathLevelParameterRule()
         val swagger = getFixture("api_spa.yaml")
         assertThat(rule.validate(swagger)!!.paths).hasSameElementsAs(listOf("/reports/jobs", "/reports/jobs/{job-id}"))
     }

--- a/server/src/test/java/de/zalando/zally/rule/ExtensibleEnumRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/ExtensibleEnumRuleTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 
 class ExtensibleEnumRuleTest {
 
-    val rule = ExtensibleEnumRule()
+    val rule = ExtensibleEnumRule(ZalandoRuleSet())
 
     @Test
     fun returnsNoViolationIfEmptySwagger() {

--- a/server/src/test/java/de/zalando/zally/rule/ExtractBasePathRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/ExtractBasePathRuleTest.kt
@@ -10,21 +10,23 @@ import org.junit.Test
 class ExtractBasePathRuleTest {
     val DESC_PATTERN = "All paths start with prefix '%s'. This prefix could be part of base path."
 
+    private val rule = ExtractBasePathRule(ZallyRuleSet())
+
     @Test
     fun validateEmptyPath() {
-        assertThat(ExtractBasePathRule().validate(Swagger())).isNull()
+        assertThat(rule.validate(Swagger())).isNull()
     }
 
     @Test
     fun simplePositiveCase() {
         val swagger = swaggerWithPaths("/orders/{order_id}", "/orders/{updates}", "/merchants")
-        assertThat(ExtractBasePathRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun singlePathShouldPass() {
         val swagger = swaggerWithPaths("/orders/{order_id}")
-        assertThat(ExtractBasePathRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
@@ -34,8 +36,8 @@ class ExtractBasePathRuleTest {
             "/shipment/{shipment_id}/status",
             "/shipment/{shipment_id}/details"
         )
-        val rule = ExtractBasePathRule()
-        val expected = Violation(ExtractBasePathRule(), rule.title, DESC_PATTERN.format("/shipment"),
+        val rule = rule
+        val expected = Violation(rule, rule.title, DESC_PATTERN.format("/shipment"),
             ViolationType.HINT, rule.url, emptyList())
         assertThat(rule.validate(swagger)).isEqualTo(expected)
     }
@@ -48,8 +50,8 @@ class ExtractBasePathRuleTest {
             "/queue/models/{model-id}",
             "/queue/models/summaries"
         )
-        val rule = ExtractBasePathRule()
-        val expected = Violation(ExtractBasePathRule(), rule.title, DESC_PATTERN.format("/queue/models"),
+        val rule = rule
+        val expected = Violation(rule, rule.title, DESC_PATTERN.format("/queue/models"),
             ViolationType.HINT, rule.url, emptyList())
         assertThat(rule.validate(swagger)).isEqualTo(expected)
     }
@@ -62,18 +64,18 @@ class ExtractBasePathRuleTest {
             "/applications/{app_id}",
             "/applications/"
         )
-        assertThat(ExtractBasePathRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(ExtractBasePathRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseTinbox() {
         val swagger = getFixture("api_tinbox.yaml")
-        assertThat(ExtractBasePathRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/FormatForNumbersRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/FormatForNumbersRuleTest.kt
@@ -7,16 +7,18 @@ import org.junit.Test
 
 class FormatForNumbersRuleTest {
 
+    private val rule = FormatForNumbersRule(ZalandoRuleSet(), testConfig)
+
     @Test
     fun positiveCase() {
         val swagger = getFixture("formatForNumbersValid.json")
-        assertThat(FormatForNumbersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCase() {
         val swagger = getFixture("formatForNumbersInvalid.json")
-        val result = FormatForNumbersRule(testConfig).validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf("#/parameters/PetFullPrice", "#/definitions/Pet", "/pets"))
         assertThat(result.description).contains("other_price", "full_price", "number_of_legs")
     }
@@ -24,12 +26,12 @@ class FormatForNumbersRuleTest {
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(FormatForNumbersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseTinbox() {
         val swagger = getFixture("api_tinbox.yaml")
-        assertThat(FormatForNumbersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/HyphenateHttpHeadersRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/HyphenateHttpHeadersRuleTest.kt
@@ -10,41 +10,43 @@ import org.junit.Test
 
 class HyphenateHttpHeadersRuleTest {
 
+    private val rule = HyphenateHttpHeadersRule(ZalandoRuleSet(), testConfig)
+
     @Test
     fun simplePositiveCase() {
         val swagger = swaggerWithHeaderParams("Right-Name")
-        assertThat(HyphenateHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun simpleNegativeCase() {
         val swagger = swaggerWithHeaderParams("CamelCaseName")
-        val result = HyphenateHttpHeadersRule(testConfig).validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf("parameters CamelCaseName"))
     }
 
     @Test
     fun mustAcceptValuesFromWhitelist() {
         val swagger = swaggerWithHeaderParams("ETag", "X-Trace-ID")
-        assertThat(HyphenateHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun emptySwaggerShouldPass() {
         val swagger = Swagger()
         swagger.parameters = HashMap<String, Parameter>()
-        assertThat(HyphenateHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(HyphenateHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseTinbox() {
         val swagger = getFixture("api_tinbox.yaml")
-        assertThat(HyphenateHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/InvalidApiSchemaRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/InvalidApiSchemaRuleTest.kt
@@ -8,15 +8,14 @@ import org.junit.Test
 
 class InvalidApiSchemaRuleTest {
 
-    companion object {
-        val invalidSchemaRule = InvalidApiSchemaRule(testConfig)
-    }
+    private val ruleSet = ZalandoRuleSet()
+    private val rule = InvalidApiSchemaRule(ruleSet, testConfig)
 
     @Test
     fun shouldNotFailOnCorrectYaml() {
         listOf("all_definitions.yaml", "api_spa.yaml", "api_without_scopes_defined.yaml").forEach { filePath ->
             val swaggerJson = getResourceJson(filePath)
-            val validations = invalidSchemaRule.validate(swaggerJson)
+            val validations = rule.validate(swaggerJson)
             assertThat(validations).hasSize(0)
         }
     }
@@ -25,7 +24,7 @@ class InvalidApiSchemaRuleTest {
     fun shouldNotFailOnCorrectJson() {
         listOf("api_spp.json", "snakeCaseForQueryParamsInvalidLocalParam.json", "limitNumberOfResourcesValid.json").forEach { filePath ->
             val swaggerJson = getResourceJson(filePath)
-            val validations = invalidSchemaRule.validate(swaggerJson)
+            val validations = rule.validate(swaggerJson)
             assertThat(validations).hasSize(0)
         }
     }
@@ -33,7 +32,7 @@ class InvalidApiSchemaRuleTest {
     @Test
     fun shouldProduceViolationsAnyOfOneOf() {
         val swaggerJson = getResourceJson("api_tinbox.yaml")
-        val validations = invalidSchemaRule.validate(swaggerJson)
+        val validations = rule.validate(swaggerJson)
         assertThat(validations).hasSize(2)
         assertThat(validations[0].description).isEqualTo("""instance failed to match at least one required schema among 2""")
         assertThat(validations[0].paths[0]).isEqualTo("/definitions/ConfigReviewStatusEntityJson/properties/date/type")
@@ -43,7 +42,7 @@ class InvalidApiSchemaRuleTest {
     @Test
     fun shouldProduceViolationsRequiredProperties() {
         val swaggerJson = getResourceJson("common_fields_invalid.yaml")
-        val validations = invalidSchemaRule.validate(swaggerJson)
+        val validations = rule.validate(swaggerJson)
         assertThat(validations).hasSize(1)
         assertThat(validations[0].description).isEqualTo("""object has missing required properties (["paths"])""")
     }
@@ -51,7 +50,7 @@ class InvalidApiSchemaRuleTest {
     @Test
     fun shouldProduceViolationsNotAllowedProperties() {
         val swaggerJson = getResourceJson("successResponseAsJsonObjectValid.json")
-        val validations = invalidSchemaRule.validate(swaggerJson)
+        val validations = rule.validate(swaggerJson)
         assertThat(validations).hasSize(3)
         assertThat(validations[0].description).isEqualTo("""object instance has properties ["anyOf"] which are not allowed by the schema: #/definitions/schema""")
         assertThat(validations[1].description).isEqualTo("""object instance has properties ["oneOf"] which are not allowed by the schema: #/definitions/schema""")
@@ -70,7 +69,7 @@ class InvalidApiSchemaRuleTest {
         """)
 
         val swaggerJson = getResourceJson("common_fields_invalid.yaml")
-        val validations = InvalidApiSchemaRule(config).validate(swaggerJson)
+        val validations = InvalidApiSchemaRule(ruleSet, config).validate(swaggerJson)
         assertThat(validations).hasSize(1)
         assertThat(validations[0].description).isEqualTo("""object has missing required properties (["paths"])""")
 
@@ -85,7 +84,7 @@ class InvalidApiSchemaRuleTest {
         """)
 
         val swaggerJson = getResourceJson("common_fields_invalid.yaml")
-        val validations = InvalidApiSchemaRule(config).validate(swaggerJson)
+        val validations = InvalidApiSchemaRule(ruleSet, config).validate(swaggerJson)
         assertThat(validations).hasSize(1)
         assertThat(validations[0].description).isEqualTo("""object has missing required properties (["paths"])""")
 

--- a/server/src/test/java/de/zalando/zally/rule/JsonSchemaValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/JsonSchemaValidatorTest.kt
@@ -1,7 +1,7 @@
 package de.zalando.zally.rule
 
 import com.google.common.io.Resources
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class JsonSchemaValidatorTest {
@@ -24,8 +24,8 @@ class JsonSchemaValidatorTest {
         """)
 
         val valResult = jsonSchemaValidator.validate(jsonToValidate)
-        Assertions.assertThat(valResult.isSuccess).isFalse()
-        Assertions.assertThat(valResult.messages[0].message).isEqualTo("numeric instance is lower than the required minimum (minimum: 0, found: -10)")
+        assertThat(valResult.isSuccess).isFalse()
+        assertThat(valResult.messages[0].message).isEqualTo("numeric instance is lower than the required minimum (minimum: 0, found: -10)")
     }
 
     @Test
@@ -40,7 +40,7 @@ class JsonSchemaValidatorTest {
         val specJson = ObjectTreeReader().readYaml(Resources.getResource("fixtures/api_tinbox.yaml"))
 
         val valResult = jsonSchemaValidator.validate(specJson)
-        Assertions.assertThat(valResult.isSuccess).isFalse()
-        Assertions.assertThat(valResult.messages[0].message).isEqualTo("instance failed to match at least one required schema among 2")
+        assertThat(valResult.isSuccess).isFalse()
+        assertThat(valResult.messages[0].message).isEqualTo("instance failed to match at least one required schema among 2")
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/KebabCaseInPathSegmentsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/KebabCaseInPathSegmentsRuleTest.kt
@@ -13,34 +13,36 @@ class KebabCaseInPathSegmentsRuleTest {
     private val wrongTestPath1 = "/shipment_order/{shipment_order_id}"
     private val wrongTestPath2 = "/partner-order/{partner_order_id}/partner-order1/{partner_order_id}"
 
+    private val rule = KebabCaseInPathSegmentsRule(ZalandoRuleSet())
+
     @Test
     fun emptySwagger() {
-        assertThat(KebabCaseInPathSegmentsRule().validate(Swagger())).isNull()
+        assertThat(rule.validate(Swagger())).isNull()
     }
 
     @Test
     fun validateNormalPath() {
         val swagger = swaggerWithPaths(testPath1)
-        assertThat(KebabCaseInPathSegmentsRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun validateMultipleNormalPaths() {
         val swagger = swaggerWithPaths(testPath1, testPath2, testPath3)
-        assertThat(KebabCaseInPathSegmentsRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun validateFalsePath() {
         val swagger = swaggerWithPaths(wrongTestPath1)
-        val result = KebabCaseInPathSegmentsRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf(wrongTestPath1))
     }
 
     @Test
     fun validateMultipleFalsePaths() {
         val swagger = swaggerWithPaths(wrongTestPath1, testPath2, wrongTestPath2)
-        val result = KebabCaseInPathSegmentsRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf(wrongTestPath1, wrongTestPath2))
     }
 

--- a/server/src/test/java/de/zalando/zally/rule/LimitNumberOfResourcesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/LimitNumberOfResourcesRuleTest.kt
@@ -7,16 +7,18 @@ import org.junit.Test
 
 class LimitNumberOfResourcesRuleTest {
 
+    private val rule = LimitNumberOfResourcesRule(ZalandoRuleSet(), testConfig)
+
     @Test
     fun positiveCase() {
         val swagger = getFixture("limitNumberOfResourcesValid.json")
-        assertThat(LimitNumberOfResourcesRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCase() {
         val swagger = getFixture("limitNumberOfResourcesInvalid.json")
-        val result = LimitNumberOfResourcesRule(testConfig).validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf(
             "/items",
             "/items/{item_id}",

--- a/server/src/test/java/de/zalando/zally/rule/LimitNumberOfSubresourcesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/LimitNumberOfSubresourcesRuleTest.kt
@@ -8,16 +8,18 @@ import org.junit.Test
 class LimitNumberOfSubresourcesRuleTest {
     val ruleConfig = testConfig
 
+    private val rule = LimitNumberOfSubresourcesRule(ZalandoRuleSet(), ruleConfig)
+
     @Test
     fun positiveCase() {
         val swagger = getFixture("limitNumberOfSubresourcesValid.json")
-        assertThat(LimitNumberOfSubresourcesRule(ruleConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCase() {
         val swagger = getFixture("limitNumberOfSubresourcesInvalid.json")
-        val result = LimitNumberOfSubresourcesRule(ruleConfig).validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(
             listOf("/items/{some_id}/item_level_1/{level1_id}/item-level-2/{level2_id}/item-level-3/{level3_id}/item-level-4")
         )
@@ -26,12 +28,12 @@ class LimitNumberOfSubresourcesRuleTest {
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(LimitNumberOfSubresourcesRule(ruleConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseSpa() {
         val swagger = getFixture("api_spa.yaml")
-        assertThat(LimitNumberOfSubresourcesRule(ruleConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/MediaTypesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/MediaTypesRuleTest.kt
@@ -10,7 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class MediaTypesRuleTest {
-    private val rule = MediaTypesRule()
+    private val rule = MediaTypesRule(ZalandoRuleSet())
 
     fun swaggerWithMediaTypes(vararg pathToMedia: Pair<String, List<String>>): Swagger =
         Swagger().apply {

--- a/server/src/test/java/de/zalando/zally/rule/NestedPathsMayBeRootPathsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/NestedPathsMayBeRootPathsRuleTest.kt
@@ -6,16 +6,18 @@ import org.junit.Test
 
 class NestedPathsMayBeRootPathsRuleTest {
 
+    private val rule = NestedPathsMayBeRootPathsRule(ZalandoRuleSet())
+
     @Test
     fun avoidLinkHeadersValidJson() {
         val swagger = getFixture("api_spp.json")
-        val result = NestedPathsMayBeRootPathsRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf("/products/{product_id}/updates/{update_id}"))
     }
 
     @Test
     fun avoidLinkHeadersValidYaml() {
         val swagger = getFixture("api_spa.yaml")
-        assertThat(NestedPathsMayBeRootPathsRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/NoProtocolInHostRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/NoProtocolInHostRuleTest.kt
@@ -7,45 +7,47 @@ import org.junit.Test
 
 class NoProtocolInHostRuleTest {
 
-    val expectedViolation = NoProtocolInHostRule().let {
+    private val rule = NoProtocolInHostRule(ZallyRuleSet())
+
+    val expectedViolation = rule.let {
         Violation(it, it.title, "", it.violationType, it.url, emptyList())
     }
 
     @Test
     fun emptySwagger() {
         val swagger = Swagger()
-        assertThat(NoProtocolInHostRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCase() {
         val swagger = Swagger().apply { host = "google.com" }
-        assertThat(NoProtocolInHostRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCaseHttp() {
         val swagger = Swagger().apply { host = "http://google.com" }
-        val res = NoProtocolInHostRule().validate(swagger)
+        val res = rule.validate(swagger)
         assertThat(res?.copy(description = "")).isEqualTo(expectedViolation)
     }
 
     @Test
     fun negativeCaseHttps() {
         val swagger = Swagger().apply { host = "https://google.com" }
-        val res = NoProtocolInHostRule().validate(swagger)
+        val res = rule.validate(swagger)
         assertThat(res?.copy(description = "")).isEqualTo(expectedViolation)
     }
 
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(NoProtocolInHostRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseSpa() {
         val swagger = getFixture("api_spa.yaml")
-        assertThat(NoProtocolInHostRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/NoUnusedDefinitionsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/NoUnusedDefinitionsRuleTest.kt
@@ -2,19 +2,21 @@ package de.zalando.zally.rule
 
 import de.zalando.zally.getFixture
 import io.swagger.models.Swagger
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class NoUnusedDefinitionsRuleTest {
+    private val rule = NoUnusedDefinitionsRule(ZallyRuleSet())
+
     @Test
     fun positiveCase() {
-        Assertions.assertThat(NoUnusedDefinitionsRule().validate(getFixture("unusedDefinitionsValid.json"))).isNull()
+        assertThat(rule.validate(getFixture("unusedDefinitionsValid.json"))).isNull()
     }
 
     @Test
     fun negativeCase() {
-        val results = NoUnusedDefinitionsRule().validate(getFixture("unusedDefinitionsInvalid.json"))!!.paths
-        Assertions.assertThat(results).hasSameElementsAs(listOf(
+        val results = rule.validate(getFixture("unusedDefinitionsInvalid.json"))!!.paths
+        assertThat(results).hasSameElementsAs(listOf(
             "#/definitions/PetName",
             "#/parameters/FlowId"
         ))
@@ -23,19 +25,19 @@ class NoUnusedDefinitionsRuleTest {
     @Test
     fun emptySwaggerShouldPass() {
         val swagger = Swagger()
-        Assertions.assertThat(NoUnusedDefinitionsRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        Assertions.assertThat(NoUnusedDefinitionsRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseTinbox() {
         val swagger = getFixture("api_tinbox.yaml")
-        Assertions.assertThat(NoUnusedDefinitionsRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
 }

--- a/server/src/test/java/de/zalando/zally/rule/NoVersionInUriRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/NoVersionInUriRuleTest.kt
@@ -7,47 +7,49 @@ import org.junit.Test
 
 class NoVersionInUriRuleTest {
 
+    private val rule = NoVersionInUriRule(ZalandoRuleSet())
+
     val expectedViolation = Violation(
-        NoVersionInUriRule(),
+            rule,
         "Do Not Use URI Versioning",
         "basePath attribute contains version number",
         ViolationType.MUST,
-        NoVersionInUriRule().url,
+        rule.url,
         emptyList())
 
     @Test
     fun returnsViolationsWhenVersionIsInTheBeginingOfBasePath() {
         val swagger = Swagger().apply { basePath = "/v1/tests" }
-        assertThat(NoVersionInUriRule().validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
     }
 
     @Test
     fun returnsViolationsWhenVersionIsInTheMiddleOfBasePath() {
         val swagger = Swagger().apply { basePath = "/api/v1/tests" }
-        assertThat(NoVersionInUriRule().validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
     }
 
     @Test
     fun returnsViolationsWhenVersionIsInTheEndOfBasePath() {
         val swagger = Swagger().apply { basePath = "/api/v1" }
-        assertThat(NoVersionInUriRule().validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
     }
 
     @Test
     fun returnsViolationsWhenVersionIsBig() {
         val swagger = Swagger().apply { basePath = "/v1024/tests" }
-        assertThat(NoVersionInUriRule().validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
     }
 
     @Test
     fun returnsEmptyViolationListWhenNoVersionFoundInURL() {
         val swagger = Swagger().apply { basePath = "/violations/" }
-        assertThat(NoVersionInUriRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun returnsEmptyViolationListWhenBasePathIsNull() {
         val swagger = Swagger()
-        assertThat(NoVersionInUriRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/NotSpecifyStandardErrorCodesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/NotSpecifyStandardErrorCodesRuleTest.kt
@@ -2,7 +2,7 @@ package de.zalando.zally.rule
 
 import de.zalando.zally.swaggerWithOperations
 import de.zalando.zally.testConfig
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class NotSpecifyStandardErrorCodesRuleTest {
@@ -15,13 +15,15 @@ class NotSpecifyStandardErrorCodesRuleTest {
 
     private val allOperations = listOf("get", "post", "put", "patch", "delete", "head", "options")
 
+    private val rule = NotSpecifyStandardErrorCodesRule(ZalandoRuleSet(), testConfig)
+
     @Test
     fun shouldPassIfErrorCodeNotStandard() {
         val operations = allOperations.associateBy({ it }, { notStandardErrorCodes })
 
         val swagger = swaggerWithOperations(operations)
 
-        Assertions.assertThat(NotSpecifyStandardErrorCodesRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
@@ -39,8 +41,8 @@ class NotSpecifyStandardErrorCodesRuleTest {
             }
         }
 
-        val violation = NotSpecifyStandardErrorCodesRule(testConfig).validate(swagger)
+        val violation = rule.validate(swagger)
 
-        Assertions.assertThat(violation?.paths.orEmpty()).containsExactlyInAnyOrder(*expectedPaths.toTypedArray())
+        assertThat(violation?.paths.orEmpty()).containsExactlyInAnyOrder(*expectedPaths.toTypedArray())
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/PascalCaseHttpHeadersRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/PascalCaseHttpHeadersRuleTest.kt
@@ -9,53 +9,55 @@ import org.junit.Test
 
 class PascalCaseHttpHeadersRuleTest {
 
+    private val rule = PascalCaseHttpHeadersRule(ZalandoRuleSet(), testConfig)
+
     @Test
     fun simplePoisitiveCase() {
         val swagger = swaggerWithHeaderParams("Right-Name")
-        assertThat(PascalCaseHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun simpleNegativeCase() {
         val swagger = swaggerWithHeaderParams("kebap-case-name")
-        val result = PascalCaseHttpHeadersRule(testConfig).validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf("parameters kebap-case-name"))
     }
 
     @Test
     fun mustAcceptETag() {
         val swagger = swaggerWithHeaderParams("ETag")
-        assertThat(PascalCaseHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun mustAccepZalandoHeaders() {
         val swagger = swaggerWithHeaderParams("X-Flow-ID", "X-UID", "X-Tenant-ID", "X-Sales-Channel", "X-Frontend-Type",
             "X-Device-Type", "X-Device-OS", "X-App-Domain")
-        assertThat(PascalCaseHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun mustAcceptDigits() {
         val swagger = swaggerWithHeaderParams("X-P1n-Id")
-        assertThat(PascalCaseHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun emptySwaggerShouldPass() {
-        assertThat(PascalCaseHttpHeadersRule(testConfig).validate(Swagger())).isNull()
+        assertThat(rule.validate(Swagger())).isNull()
     }
 
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(PascalCaseHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseTinbox() {
         val swagger = getFixture("api_tinbox.yaml")
-        assertThat(PascalCaseHttpHeadersRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }
 

--- a/server/src/test/java/de/zalando/zally/rule/PluralizeNamesForArraysRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/PluralizeNamesForArraysRuleTest.kt
@@ -6,16 +6,18 @@ import org.junit.Test
 
 class PluralizeNamesForArraysRuleTest {
 
+    private val rule = PluralizeNamesForArraysRule(ZalandoRuleSet())
+
     @Test
     fun positiveCase() {
         val swagger = getFixture("pluralizeArrayNamesValid.json")
-        assertThat(PluralizeNamesForArraysRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCase() {
         val swagger = getFixture("pluralizeArrayNamesInvalid.json")
-        val result = PluralizeNamesForArraysRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf("#/definitions/Pet"))
         assertThat(result.description).contains("name", "tag")
     }
@@ -23,12 +25,12 @@ class PluralizeNamesForArraysRuleTest {
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(PluralizeNamesForArraysRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCaseTinbox() {
         val swagger = getFixture("api_tinbox.yaml")
-        assertThat(PluralizeNamesForArraysRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/PluralizeResourceNamesRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/PluralizeResourceNamesRuleTest.kt
@@ -7,35 +7,37 @@ import org.junit.Test
 
 class PluralizeResourceNamesRuleTest {
 
+    private val rule = PluralizeResourceNamesRule(ZalandoRuleSet(), testConfig)
+
     @Test
     fun positiveCase() {
         val swagger = getFixture("pluralizeResourcesValid.json")
-        assertThat(PluralizeResourceNamesRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCase() {
         val swagger = getFixture("pluralizeResourcesInvalid.json")
-        val result = PluralizeResourceNamesRule(testConfig).validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf("/pet/cats", "/pets/cats/{cat-id}/tail/{tail-id}/strands"))
     }
 
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(PluralizeResourceNamesRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun positiveCasePathsWithTheApiPrefix() {
         val swagger = getFixture("spp_with_paths_having_api_prefix.json")
-        assertThat(PluralizeResourceNamesRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCaseTinbox() {
         val swagger = getFixture("api_tinbox.yaml")
-        val result = PluralizeResourceNamesRule(testConfig).validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf("/queue/configs/{config-id}", "/queue/models",
             "/queue/models/{model-id}", "/queue/summaries"))
     }

--- a/server/src/test/java/de/zalando/zally/rule/QueryParameterCollectionFormatRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/QueryParameterCollectionFormatRuleTest.kt
@@ -5,10 +5,12 @@ import io.swagger.models.Operation
 import io.swagger.models.Path
 import io.swagger.models.Swagger
 import io.swagger.models.parameters.QueryParameter
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class QueryParameterCollectionFormatRuleTest {
+
+    private val rule = QueryParameterCollectionFormatRule(ZalandoRuleSet())
 
     @Test
     fun negativeCaseCollectionFormatNotSupported() {
@@ -16,9 +18,9 @@ class QueryParameterCollectionFormatRuleTest {
             parameters = mapOf("test" to QueryParameter().apply { name = "test"; type = "array"; collectionFormat = "notSupported" })
         }
 
-        val result = QueryParameterCollectionFormatRule().validate(swagger)!!
-        Assertions.assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
-        Assertions.assertThat(result.rule.code).isEqualTo("S011")
+        val result = rule.validate(swagger)!!
+        assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
+        assertThat(result.rule.code).isEqualTo("S011")
     }
 
     @Test
@@ -28,9 +30,9 @@ class QueryParameterCollectionFormatRuleTest {
             paths = mapOf("/apis" to Path().apply { get = Operation().apply { parameters = paramList } })
         }
 
-        val result = QueryParameterCollectionFormatRule().validate(swagger)!!
-        Assertions.assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
-        Assertions.assertThat(result.rule.code).isEqualTo("S011")
+        val result = rule.validate(swagger)!!
+        assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
+        assertThat(result.rule.code).isEqualTo("S011")
     }
 
     @Test
@@ -39,9 +41,9 @@ class QueryParameterCollectionFormatRuleTest {
             parameters = mapOf("test" to QueryParameter().apply { name = "test"; type = "array"; collectionFormat = null })
         }
 
-        val result = QueryParameterCollectionFormatRule().validate(swagger)!!
-        Assertions.assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
-        Assertions.assertThat(result.rule.code).isEqualTo("S011")
+        val result = rule.validate(swagger)!!
+        assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
+        assertThat(result.rule.code).isEqualTo("S011")
     }
 
     @Test
@@ -51,9 +53,9 @@ class QueryParameterCollectionFormatRuleTest {
             paths = mapOf("/apis" to Path().apply { get = Operation().apply { parameters = paramList } })
         }
 
-        val result = QueryParameterCollectionFormatRule().validate(swagger)!!
-        Assertions.assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
-        Assertions.assertThat(result.rule.code).isEqualTo("S011")
+        val result = rule.validate(swagger)!!
+        assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
+        assertThat(result.rule.code).isEqualTo("S011")
     }
 
     @Test
@@ -62,7 +64,7 @@ class QueryParameterCollectionFormatRuleTest {
             parameters = mapOf("test" to QueryParameter().apply { name = "test"; type = "array"; collectionFormat = "csv" })
         }
 
-        Assertions.assertThat(QueryParameterCollectionFormatRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
@@ -72,7 +74,7 @@ class QueryParameterCollectionFormatRuleTest {
             paths = mapOf("/apis" to Path().apply { get = Operation().apply { parameters = paramList } })
         }
 
-        Assertions.assertThat(QueryParameterCollectionFormatRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
@@ -81,7 +83,7 @@ class QueryParameterCollectionFormatRuleTest {
             parameters = mapOf("test" to QueryParameter().apply { name = "test"; type = "array"; collectionFormat = "multi" })
         }
 
-        Assertions.assertThat(QueryParameterCollectionFormatRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
@@ -91,7 +93,7 @@ class QueryParameterCollectionFormatRuleTest {
             paths = mapOf("/apis" to Path().apply { get = Operation().apply { parameters = paramList } })
         }
 
-        Assertions.assertThat(QueryParameterCollectionFormatRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
 }

--- a/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RulesPolicyTest {
-    class TestRule(val result: Violation?) : SwaggerRule() {
+    class TestRule(val result: Violation?) : SwaggerRule(ZalandoRuleSet()) {
         override val title = "Test Rule"
         override val url = null
         override val violationType = ViolationType.MUST

--- a/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
@@ -15,7 +15,7 @@ class RulesValidatorTest {
 
     val swaggerContent = javaClass.classLoader.getResource("fixtures/api_spp.json").readText(Charsets.UTF_8)
 
-    class FirstRule(val result: Violation?) : SwaggerRule() {
+    class FirstRule(val result: Violation?) : SwaggerRule(ZalandoRuleSet()) {
         override val title = "First Rule"
         override val url = null
         override val violationType = ViolationType.SHOULD
@@ -24,7 +24,7 @@ class RulesValidatorTest {
         override fun validate(swagger: Swagger): Violation? = result
     }
 
-    class SecondRule(val result: Violation?) : SwaggerRule() {
+    class SecondRule(val result: Violation?) : SwaggerRule(ZalandoRuleSet()) {
         override val title = "Second Rule"
         override val url = null
         override val violationType = ViolationType.MUST

--- a/server/src/test/java/de/zalando/zally/rule/SecureWithOAuth2RuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/SecureWithOAuth2RuleTest.kt
@@ -11,25 +11,27 @@ import org.junit.Test
 
 class SecureWithOAuth2RuleTest {
 
+    private val rule = SecureWithOAuth2Rule(ZalandoRuleSet())
+
     val expectedOauthViolation = Violation(
-            SecureWithOAuth2Rule(),
+            rule,
             "Secure Endpoints with OAuth 2.0",
             "No OAuth2 security definitions found",
             ViolationType.MUST,
-            SecureWithOAuth2Rule().url,
+            rule.url,
             emptyList())
 
     val expectedHttpsViolation = Violation(
-            SecureWithOAuth2Rule(),
+            rule,
             "Secure Endpoints with OAuth 2.0",
             "OAuth2 should be only used together with https",
             ViolationType.MUST,
-            SecureWithOAuth2Rule().url,
+            rule.url,
             emptyList())
 
     @Test
     fun emptySwagger() {
-        assertThat(SecureWithOAuth2Rule().validate(Swagger())).isEqualTo(expectedOauthViolation)
+        assertThat(rule.validate(Swagger())).isEqualTo(expectedOauthViolation)
     }
 
     @Test
@@ -37,7 +39,7 @@ class SecureWithOAuth2RuleTest {
         val swagger = Swagger().apply {
             securityDefinitions = emptyMap()
         }
-        assertThat(SecureWithOAuth2Rule().validate(swagger)).isEqualTo(expectedOauthViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedOauthViolation)
     }
 
     @Test
@@ -48,7 +50,7 @@ class SecureWithOAuth2RuleTest {
                 "ApiKey" to ApiKeyAuthDefinition()
             )
         }
-        assertThat(SecureWithOAuth2Rule().validate(swagger)).isEqualTo(expectedOauthViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedOauthViolation)
     }
 
     @Test
@@ -59,7 +61,7 @@ class SecureWithOAuth2RuleTest {
                     "Oauth2" to OAuth2Definition()
             )
         }
-        assertThat(SecureWithOAuth2Rule().validate(swagger)).isEqualTo(expectedHttpsViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedHttpsViolation)
     }
 
     @Test
@@ -71,6 +73,6 @@ class SecureWithOAuth2RuleTest {
                 "Oauth2" to OAuth2Definition()
             )
         }
-        assertThat(SecureWithOAuth2Rule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/SnakeCaseForQueryParamsRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/SnakeCaseForQueryParamsRuleTest.kt
@@ -11,26 +11,28 @@ class SnakeCaseForQueryParamsRuleTest {
     private val invalidSwaggerWIthInternalRef = getFixture("snakeCaseForQueryParamsInvalidInternalRef.json")
     private val invalidSwaggerWithExternalRef = getFixture("snakeCaseForQueryParamsInvalidExternalRef.json")
 
+    private val rule = SnakeCaseForQueryParamsRule(ZalandoRuleSet())
+
     @Test
     fun shouldFindNoViolations() {
-        assertThat(SnakeCaseForQueryParamsRule().validate(validSwagger)).isNull()
+        assertThat(rule.validate(validSwagger)).isNull()
     }
 
     @Test
     fun shouldFindViolationsInLocalRef() {
-        val result = SnakeCaseForQueryParamsRule().validate(invalidSwaggerWithLocalParam)!!
+        val result = rule.validate(invalidSwaggerWithLocalParam)!!
         assertThat(result.paths).hasSameElementsAs(listOf("/items GET"))
     }
 
     @Test
     fun shouldFindViolationsInInternalRef() {
-        val result = SnakeCaseForQueryParamsRule().validate(invalidSwaggerWIthInternalRef)!!
+        val result = rule.validate(invalidSwaggerWIthInternalRef)!!
         assertThat(result.paths).hasSameElementsAs(listOf("/items GET"))
     }
 
     @Test
     fun shouldFindViolationsInExternalRef() {
-        val result = SnakeCaseForQueryParamsRule().validate(invalidSwaggerWithExternalRef)!!
+        val result = rule.validate(invalidSwaggerWithExternalRef)!!
         assertThat(result.paths).hasSameElementsAs(listOf("/items GET"))
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/SnakeCaseInPropNameRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/SnakeCaseInPropNameRuleTest.kt
@@ -8,21 +8,23 @@ import org.junit.Test
 
 class SnakeCaseInPropNameRuleTest {
 
+    private val rule = SnakeCaseInPropNameRule(ZalandoRuleSet(), testConfig)
+
     @Test
     fun emptySwagger() {
-        assertThat(SnakeCaseInPropNameRule(testConfig).validate(Swagger())).isNull()
+        assertThat(rule.validate(Swagger())).isNull()
     }
 
     @Test
     fun validateNormalProperty() {
         val swagger = swaggerWithDefinitions("ExampleDefinition" to listOf("test_property"))
-        assertThat(SnakeCaseInPropNameRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun validateMultipleNormalProperties() {
         val swagger = swaggerWithDefinitions("ExampleDefinition" to listOf("test_property", "test_property_two"))
-        assertThat(SnakeCaseInPropNameRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
@@ -31,13 +33,13 @@ class SnakeCaseInPropNameRuleTest {
             "ExampleDefinition" to listOf("test_property"),
             "ExampleDefinitionTwo" to listOf("test_property_two")
         )
-        assertThat(SnakeCaseInPropNameRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun validateFalseProperty() {
         val swagger = swaggerWithDefinitions("ExampleDefinition" to listOf("TEST_PROPERTY"))
-        val result = SnakeCaseInPropNameRule(testConfig).validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.description).contains("TEST_PROPERTY")
         assertThat(result.paths).hasSameElementsAs(listOf("#/definitions/ExampleDefinition"))
     }
@@ -48,7 +50,7 @@ class SnakeCaseInPropNameRuleTest {
             "ExampleDefinition" to listOf("TEST_PROPERTY"),
             "ExampleDefinitionTwo" to listOf("test_property_TWO")
         )
-        val result = SnakeCaseInPropNameRule(testConfig).validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.description).contains("TEST_PROPERTY", "test_property_TWO")
         assertThat(result.paths).hasSameElementsAs(listOf(
             "#/definitions/ExampleDefinition",
@@ -59,6 +61,6 @@ class SnakeCaseInPropNameRuleTest {
     @Test
     fun notFireOnWhitelistedProperty() {
         val swagger = swaggerWithDefinitions("ExampleDefinition" to listOf("_links"))
-        assertThat(SnakeCaseInPropNameRule(testConfig).validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/SuccessResponseAsJsonObjectRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/SuccessResponseAsJsonObjectRuleTest.kt
@@ -10,25 +10,27 @@ class SuccessResponseAsJsonObjectRuleTest {
     private val invalidSwagger = getFixture("successResponseAsJsonObjectInvalid.json")
     private val npeSwagger = getFixture("sample_swagger_api.yaml")
 
+    private val rule = SuccessResponseAsJsonObjectRule(ZalandoRuleSet())
+
     @Test
     fun positiveCase() {
-        assertThat(SuccessResponseAsJsonObjectRule().validate(validSwagger)).isNull()
+        assertThat(rule.validate(validSwagger)).isNull()
     }
 
     @Test
     fun negativeCase() {
-        val result = SuccessResponseAsJsonObjectRule().validate(invalidSwagger)!!
+        val result = rule.validate(invalidSwagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf("/pets GET 200", "/pets POST 200"))
     }
 
     @Test
     fun positiveCaseSpp() {
         val swagger = getFixture("api_spp.json")
-        assertThat(SuccessResponseAsJsonObjectRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun npeBug() {
-        assertThat(SuccessResponseAsJsonObjectRule().validate(npeSwagger)).isNotNull()
+        assertThat(rule.validate(npeSwagger)).isNotNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/Use429HeaderForRateLimitRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/Use429HeaderForRateLimitRuleTest.kt
@@ -5,22 +5,24 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class Use429HeaderForRateLimitRuleTest {
+    private val rule = Use429HeaderForRateLimitRule(ZalandoRuleSet())
+
     @Test
     fun positiveCase() {
         val swagger = getFixture("use429HeadersForRateLimitValid.json")
-        assertThat(Use429HeaderForRateLimitRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun negativeCase() {
         val swagger = getFixture("use429HeadersForRateLimitInvalidHeader.json")
-        val result = Use429HeaderForRateLimitRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf("/pets GET 429", "/pets POST 429", "/pets PUT 429"))
     }
 
     @Test
     fun positiveCaseSpa() {
         val swagger = getFixture("api_spa.yaml")
-        assertThat(Use429HeaderForRateLimitRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/UsePasswordFlowWithOauth2RuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/UsePasswordFlowWithOauth2RuleTest.kt
@@ -5,17 +5,19 @@ import io.swagger.models.Swagger
 import io.swagger.models.auth.ApiKeyAuthDefinition
 import io.swagger.models.auth.BasicAuthDefinition
 import io.swagger.models.auth.OAuth2Definition
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class UsePasswordFlowWithOauth2RuleTest {
 
+    private val rule = UsePasswordFlowWithOauth2Rule(ZalandoRuleSet())
+
     val expectedViolation = Violation(
-            UsePasswordFlowWithOauth2Rule(),
+            rule,
             "Set Flow to Password When Using OAuth 2.0",
             "OAuth2 security definitions should use password flow",
             ViolationType.MUST,
-            UsePasswordFlowWithOauth2Rule().url,
+            rule.url,
             emptyList())
 
     @Test
@@ -26,7 +28,7 @@ class UsePasswordFlowWithOauth2RuleTest {
                     "ApiKey" to ApiKeyAuthDefinition()
             )
         }
-        Assertions.assertThat(UsePasswordFlowWithOauth2Rule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
@@ -39,7 +41,7 @@ class UsePasswordFlowWithOauth2RuleTest {
                     }
             )
         }
-        Assertions.assertThat(UsePasswordFlowWithOauth2Rule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
@@ -52,7 +54,7 @@ class UsePasswordFlowWithOauth2RuleTest {
                     }
             )
         }
-        Assertions.assertThat(UsePasswordFlowWithOauth2Rule().validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
     }
 
     @Test
@@ -63,7 +65,7 @@ class UsePasswordFlowWithOauth2RuleTest {
                     "Oauth2" to OAuth2Definition()
             )
         }
-        Assertions.assertThat(UsePasswordFlowWithOauth2Rule().validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
     }
 
     @Test
@@ -76,6 +78,6 @@ class UsePasswordFlowWithOauth2RuleTest {
                     }
             )
         }
-        Assertions.assertThat(UsePasswordFlowWithOauth2Rule().validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/UseProblemJsonRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/UseProblemJsonRuleTest.kt
@@ -6,16 +6,18 @@ import org.junit.Test
 
 class UseProblemJsonRuleTest {
 
+    private val rule = UseProblemJsonRule(ZalandoRuleSet())
+
     @Test
     fun shouldReturnNoViolationsWhenErrorsReferencingToProblemJson() {
         val swagger = getFixture("problem_json.yaml")
-        assertThat(UseProblemJsonRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun shouldReturnViolationsWhenErrorsReferencingToProblemJsonButNotProducingJson() {
         val swagger = getFixture("problem_json_not_produces_json.yaml")
-        val result = UseProblemJsonRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf(
             "/products GET 400",
             "/products GET 401",
@@ -28,13 +30,13 @@ class UseProblemJsonRuleTest {
     @Test
     fun shouldReturnNoViolationsWhenOperationsAreProducingJson() {
         val swagger = getFixture("problem_json_operations_produce_json.yaml")
-        assertThat(UseProblemJsonRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 
     @Test
     fun shouldReturnViolationsWhenCustomReferenceIsUsed() {
         val swagger = getFixture("api_tinbox.yaml")
-        val result = UseProblemJsonRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf(
             "/merchants GET 400",
             "/merchants GET 401",
@@ -107,7 +109,7 @@ class UseProblemJsonRuleTest {
     @Test
     fun shouldReturnViolationsWhenNoReferenceIsUsed() {
         val swagger = getFixture("api_spp.json")
-        val result = UseProblemJsonRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf(
             "/product-put-requests/{product_path} POST 400",
             "/product-put-requests/{product_path} POST 406",
@@ -130,7 +132,7 @@ class UseProblemJsonRuleTest {
     @Test
     fun shouldNotThrowExOnSchemasWithReferencesToEmptyDefinitions() {
         val swagger = getFixture("missing_definitions.yaml")
-        val result = UseProblemJsonRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.paths).hasSameElementsAs(listOf(
                 "/identifier-types/{identifier_type}/source-ids/{source_identifier} GET 401",
                 "/identifier-types/{identifier_type}/source-ids/{source_identifier} GET 403",

--- a/server/src/test/java/de/zalando/zally/rule/UseSpecificHttpStatusCodesTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/UseSpecificHttpStatusCodesTest.kt
@@ -2,10 +2,12 @@ package de.zalando.zally.rule
 
 import de.zalando.zally.swaggerWithOperations
 import de.zalando.zally.testConfig
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class UseSpecificHttpStatusCodesTest {
+    private val codes = UseSpecificHttpStatusCodes(ZalandoRuleSet(), testConfig)
+
     @Test
     fun shouldPassIfOperationsAreAllowed() {
         val allowedToAll = listOf(
@@ -22,7 +24,7 @@ class UseSpecificHttpStatusCodesTest {
 
         val swagger = swaggerWithOperations(operations)
 
-        Assertions.assertThat(UseSpecificHttpStatusCodes(testConfig).validate(swagger)).isNull()
+        assertThat(codes.validate(swagger)).isNull()
     }
 
     @Test
@@ -47,8 +49,8 @@ class UseSpecificHttpStatusCodesTest {
             }
         }
 
-        val violation = UseSpecificHttpStatusCodes(testConfig).validate(swagger)
+        val violation = codes.validate(swagger)
 
-        Assertions.assertThat(violation?.paths.orEmpty()).containsExactlyInAnyOrder(*expectedPaths.toTypedArray())
+        assertThat(violation?.paths.orEmpty()).containsExactlyInAnyOrder(*expectedPaths.toTypedArray())
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/VersionInInfoSectionRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/VersionInInfoSectionRuleTest.kt
@@ -14,29 +14,31 @@ class VersionInInfoSectionRuleTest {
             }
         }
 
+    private val rule = VersionInInfoSectionRule(ZalandoRuleSet())
+
     @Test
     fun emptySwagger() {
-        val result = VersionInInfoSectionRule().validate(Swagger())!!
+        val result = rule.validate(Swagger())!!
         assertThat(result.description).contains("Version is missing")
     }
 
     @Test
     fun missingVersion() {
         val swagger = Swagger().apply { info = Info() }
-        val result = VersionInInfoSectionRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.description).contains("Version is missing")
     }
 
     @Test
     fun wrongVersionFormat() {
         val swagger = swaggerWithVersion("1.2.3-a")
-        val result = VersionInInfoSectionRule().validate(swagger)!!
+        val result = rule.validate(swagger)!!
         assertThat(result.description).contains("Specified version has incorrect format")
     }
 
     @Test
     fun correctVersion() {
         val swagger = swaggerWithVersion("1.2.3")
-        assertThat(VersionInInfoSectionRule().validate(swagger)).isNull()
+        assertThat(rule.validate(swagger)).isNull()
     }
 }

--- a/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.java
+++ b/server/src/test/java/de/zalando/zally/statistic/RestReviewStatisticsTest.java
@@ -6,6 +6,7 @@ import de.zalando.zally.dto.ApiDefinitionRequest;
 import de.zalando.zally.dto.ViolationType;
 import de.zalando.zally.rule.AvoidTrailingSlashesRule;
 import de.zalando.zally.rule.Violation;
+import de.zalando.zally.rule.ZalandoRuleSet;
 import de.zalando.zally.util.ErrorResponse;
 import de.zalando.zally.util.TestDateUtil;
 import org.junit.Test;
@@ -149,7 +150,7 @@ public class RestReviewStatisticsTest extends RestApiBaseTest {
     }
 
     private List<Violation> createRandomViolations() {
-        return Arrays.asList(new Violation(new AvoidTrailingSlashesRule(), "", "", ViolationType.MUST, "", Arrays.asList("path")));
+        return Arrays.asList(new Violation(new AvoidTrailingSlashesRule(new ZalandoRuleSet()), "", "", ViolationType.MUST, "", Arrays.asList("path")));
     }
 
     private void assertBadRequestFor(Object from, Object to) {


### PR DESCRIPTION
This is a first step in addressing #559. I'm hoping it's uncontroversial so that we can start on the next steps where things get interesting :)
- Added `RuleSet` interface along with `ZalandoRuleSet` and `ZallyRuleSet` implementations.
  - Very tempted to move Zalando and Zally rules into separate sub-packages but held off to avoid churn and controversy. Happy to add that change into the PR if supported.
- Associated existing rules with one of the `RuleSet` implementations
- Skipped merging `code` and `guideline` to `id` since that'll be better done once multiple `Check` implementations are supportable.
- Nothing changed affecting the REST API or it's clients.