### PR TITLE
fix (server): only use hibernate version 5.2 (#577)

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -57,12 +57,16 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
     compile("org.springframework.boot:spring-boot-starter-undertow")
     compile("org.springframework.boot:spring-boot-starter-actuator")
-    compile('org.springframework.boot:spring-boot-starter-data-jpa')
+    compile('org.springframework.boot:spring-boot-starter-data-jpa') {
+        exclude group: "org.hibernate", module: "hibernate-entitymanager"
+    }
     compile('org.flywaydb:flyway-core:4.1.2')
     compile('org.hsqldb:hsqldb:2.3.3')
     compile('org.postgresql:postgresql:42.1.1')
     compile('org.hibernate:hibernate-core:5.2.9.Final')
-    compile('org.jadira.usertype:usertype.core:6.0.1.GA')
+    compile('org.jadira.usertype:usertype.core:6.0.1.GA') {
+        exclude group: "org.hibernate", module: "hibernate-entitymanager"
+    }
     compile("com.fasterxml.jackson.module:jackson-module-parameter-names")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")


### PR DESCRIPTION
closes #577 


this PR cleans up the dependency tree: 
``
./gradlew dependencyInsight --dependency hibernate
``

```
org.hibernate:hibernate-core:5.2.9.Final (selected by rule)
\--- compileClasspath

org.hibernate:hibernate-core:5.0.12.Final -> 5.2.9.Final
\--- org.springframework.boot:spring-boot-starter-data-jpa:1.5.7.RELEASE
     \--- compileClasspath

org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final
\--- org.hibernate:hibernate-core:5.2.9.Final
     +--- compileClasspath
     \--- org.springframework.boot:spring-boot-starter-data-jpa:1.5.7.RELEASE
          \--- compileClasspath
```
