### PR TITLE
All rule-ignoring is performed by RulesPolicy

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/AbstractRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/AbstractRule.kt
@@ -2,6 +2,8 @@ package de.zalando.zally.rule
 
 abstract class AbstractRule : Rule {
 
+    val zallyIgnoreExtension = "x-zally-ignore"
+
     override val name: String = javaClass.simpleName
 
     override fun equals(other: Any?): Boolean {

--- a/server/src/main/java/de/zalando/zally/rule/AbstractRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/AbstractRule.kt
@@ -2,8 +2,6 @@ package de.zalando.zally.rule
 
 abstract class AbstractRule : Rule {
 
-    val zallyIgnoreExtension = "x-zally-ignore"
-
     override val name: String = javaClass.simpleName
 
     override fun equals(other: Any?): Boolean {

--- a/server/src/main/java/de/zalando/zally/rule/ApiValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/ApiValidator.kt
@@ -1,5 +1,5 @@
 package de.zalando.zally.rule
 
 interface ApiValidator {
-    fun validate(swaggerContent: String, ignoreRules: List<String> = emptyList()): List<Violation>
+    fun validate(swaggerContent: String, requestPolicy: RulesPolicy): List<Violation>
 }

--- a/server/src/main/java/de/zalando/zally/rule/CompositeRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/CompositeRulesValidator.kt
@@ -8,7 +8,8 @@ class CompositeRulesValidator(
         @Autowired val swaggerRulesValidator: SwaggerRulesValidator,
         @Autowired val jsonRulesValidator: JsonRulesValidator) : ApiValidator {
 
-    override fun validate(swaggerContent: String, ignoreRules: List<String>): List<Violation> =
-            swaggerRulesValidator.validate(swaggerContent, ignoreRules) + jsonRulesValidator.validate(swaggerContent, ignoreRules)
+    override fun validate(swaggerContent: String, requestPolicy: RulesPolicy): List<Violation> =
+            swaggerRulesValidator.validate(swaggerContent, requestPolicy) +
+                    jsonRulesValidator.validate(swaggerContent, requestPolicy)
 
 }

--- a/server/src/main/java/de/zalando/zally/rule/JsonRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonRule.kt
@@ -4,6 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode
 
 abstract class JsonRule : AbstractRule() {
 
+    fun accepts(swagger: JsonNode): Boolean {
+        val ignoredCodes = swagger.get(zallyIgnoreExtension)
+        return ignoredCodes == null
+                || !ignoredCodes.isArray
+                || code !in ignoredCodes.map { it.asText() }
+    }
+
     abstract fun validate(swagger: JsonNode): Iterable<Violation>
 
 }

--- a/server/src/main/java/de/zalando/zally/rule/JsonRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonRule.kt
@@ -4,13 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode
 
 abstract class JsonRule : AbstractRule() {
 
-    fun accepts(swagger: JsonNode): Boolean {
-        val ignoredCodes = swagger.get(zallyIgnoreExtension)
-        return ignoredCodes == null
-                || !ignoredCodes.isArray
-                || code !in ignoredCodes.map { it.asText() }
-    }
-
     abstract fun validate(swagger: JsonNode): Iterable<Violation>
 
 }

--- a/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
@@ -1,6 +1,5 @@
 package de.zalando.zally.rule
 
-import com.fasterxml.jackson.databind.JsonNode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -8,10 +7,14 @@ import org.springframework.stereotype.Component
 class JsonRulesValidator(@Autowired rules: List<JsonRule>,
                          @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<JsonRule>(rules, invalidApiRule) {
 
+    private val jsonTreeReader = ObjectTreeReader()
+
     @Throws(java.lang.Exception::class)
-    override fun createRuleChecker(json: JsonNode): (JsonRule) -> Iterable<Violation> {
+    override fun createRuleChecker(swaggerContent: String): (JsonRule) -> Iterable<Violation> {
+        val swaggerJson = jsonTreeReader.read(swaggerContent)
         return {
-            it.validate(json)
+            if (it.accepts(swaggerJson)) it.validate(swaggerJson)
+            else emptyList()
         }
     }
 }

--- a/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
@@ -5,8 +5,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class JsonRulesValidator(@Autowired rules: List<JsonRule>,
-                         @Autowired rulesPolicy: RulesPolicy,
-                         @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<JsonRule>(rules, rulesPolicy, invalidApiRule) {
+                         @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<JsonRule>(rules, invalidApiRule) {
 
     private val jsonTreeReader = ObjectTreeReader()
 
@@ -18,5 +17,4 @@ class JsonRulesValidator(@Autowired rules: List<JsonRule>,
             else emptyList()
         }
     }
-
 }

--- a/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/JsonRulesValidator.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.rule
 
+import com.fasterxml.jackson.databind.JsonNode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -7,14 +8,10 @@ import org.springframework.stereotype.Component
 class JsonRulesValidator(@Autowired rules: List<JsonRule>,
                          @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<JsonRule>(rules, invalidApiRule) {
 
-    private val jsonTreeReader = ObjectTreeReader()
-
     @Throws(java.lang.Exception::class)
-    override fun createRuleChecker(swaggerContent: String): (JsonRule) -> Iterable<Violation> {
-        val swaggerJson = jsonTreeReader.read(swaggerContent)
+    override fun createRuleChecker(json: JsonNode): (JsonRule) -> Iterable<Violation> {
         return {
-            if (it.accepts(swaggerJson)) it.validate(swaggerJson)
-            else emptyList()
+            it.validate(json)
         }
     }
 }

--- a/server/src/main/java/de/zalando/zally/rule/RulesPolicy.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesPolicy.kt
@@ -8,4 +8,6 @@ class RulesPolicy(@Value("\${zally.ignoreRules:}") val ignoreRules: Array<String
     fun accepts(rule: Rule): Boolean {
         return !ignoreRules.contains(rule.code)
     }
+
+    fun withMoreIgnores(moreIgnores: List<String>) = RulesPolicy(ignoreRules + moreIgnores)
 }

--- a/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
@@ -1,16 +1,15 @@
 package de.zalando.zally.rule
 
-abstract class RulesValidator<RuleT>(val rules: List<RuleT>, val rulesPolicy: RulesPolicy, val invalidApiRule: InvalidApiSchemaRule) : ApiValidator where RuleT : Rule {
+abstract class RulesValidator<RuleT>(val rules: List<RuleT>, val invalidApiRule: InvalidApiSchemaRule) : ApiValidator where RuleT : Rule {
 
-    final override fun validate(swaggerContent: String, ignoreRules: List<String>): List<Violation> {
+    final override fun validate(swaggerContent: String, requestPolicy: RulesPolicy): List<Violation> {
         val ruleChecker = try {
             createRuleChecker(swaggerContent)
         } catch (e: Exception) {
             return listOf(invalidApiRule.getGeneralViolation())
         }
         return rules
-                .filter { it.code !in ignoreRules }
-                .filter { rulesPolicy.accepts(it) }
+                .filter { requestPolicy.accepts(it) }
                 .flatMap(ruleChecker)
                 .sortedBy(Violation::violationType)
     }

--- a/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
@@ -1,19 +1,37 @@
 package de.zalando.zally.rule
 
+import com.fasterxml.jackson.databind.JsonNode
+
 abstract class RulesValidator<RuleT>(val rules: List<RuleT>, val invalidApiRule: InvalidApiSchemaRule) : ApiValidator where RuleT : Rule {
 
+    private val zallyIgnoreExtension = "x-zally-ignore"
+
+    private val reader = ObjectTreeReader()
+
     final override fun validate(swaggerContent: String, requestPolicy: RulesPolicy): List<Violation> {
-        val ruleChecker = try {
-            createRuleChecker(swaggerContent)
+        return try {
+            val json = reader.read(swaggerContent)
+            val documentPolicy = documentPolicy(json, requestPolicy)
+
+            rules
+                    .filter { documentPolicy.accepts(it) }
+                    .flatMap(createRuleChecker(json))
+                    .sortedBy(Violation::violationType)
         } catch (e: Exception) {
-            return listOf(invalidApiRule.getGeneralViolation())
+            listOf(invalidApiRule.getGeneralViolation())
         }
-        return rules
-                .filter { requestPolicy.accepts(it) }
-                .flatMap(ruleChecker)
-                .sortedBy(Violation::violationType)
+    }
+
+    private fun documentPolicy(json: JsonNode, requestPolicy: RulesPolicy): RulesPolicy {
+        val ignoredCodes = json.path(zallyIgnoreExtension)
+        return if (ignoredCodes.isArray) {
+            val moreIgnores = ignoredCodes.map { it.asText() }
+            requestPolicy.withMoreIgnores(moreIgnores)
+        } else {
+            requestPolicy
+        }
     }
 
     @Throws(java.lang.Exception::class)
-    abstract fun createRuleChecker(swaggerContent: String): (RuleT) -> Iterable<Violation>
+    abstract fun createRuleChecker(json: JsonNode): (RuleT) -> Iterable<Violation>
 }

--- a/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesValidator.kt
@@ -1,37 +1,19 @@
 package de.zalando.zally.rule
 
-import com.fasterxml.jackson.databind.JsonNode
-
 abstract class RulesValidator<RuleT>(val rules: List<RuleT>, val invalidApiRule: InvalidApiSchemaRule) : ApiValidator where RuleT : Rule {
 
-    private val zallyIgnoreExtension = "x-zally-ignore"
-
-    private val reader = ObjectTreeReader()
-
     final override fun validate(swaggerContent: String, requestPolicy: RulesPolicy): List<Violation> {
-        return try {
-            val json = reader.read(swaggerContent)
-            val documentPolicy = documentPolicy(json, requestPolicy)
-
-            rules
-                    .filter { documentPolicy.accepts(it) }
-                    .flatMap(createRuleChecker(json))
-                    .sortedBy(Violation::violationType)
+        val ruleChecker = try {
+            createRuleChecker(swaggerContent)
         } catch (e: Exception) {
-            listOf(invalidApiRule.getGeneralViolation())
+            return listOf(invalidApiRule.getGeneralViolation())
         }
-    }
-
-    private fun documentPolicy(json: JsonNode, requestPolicy: RulesPolicy): RulesPolicy {
-        val ignoredCodes = json.path(zallyIgnoreExtension)
-        return if (ignoredCodes.isArray) {
-            val moreIgnores = ignoredCodes.map { it.asText() }
-            requestPolicy.withMoreIgnores(moreIgnores)
-        } else {
-            requestPolicy
-        }
+        return rules
+                .filter { requestPolicy.accepts(it) }
+                .flatMap(ruleChecker)
+                .sortedBy(Violation::violationType)
     }
 
     @Throws(java.lang.Exception::class)
-    abstract fun createRuleChecker(json: JsonNode): (RuleT) -> Iterable<Violation>
+    abstract fun createRuleChecker(swaggerContent: String): (RuleT) -> Iterable<Violation>
 }

--- a/server/src/main/java/de/zalando/zally/rule/SwaggerRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SwaggerRule.kt
@@ -4,6 +4,13 @@ import io.swagger.models.Swagger
 
 abstract class SwaggerRule : AbstractRule() {
 
+    fun accepts(swagger: Swagger): Boolean {
+        val ignoredCodes = swagger.vendorExtensions?.get(zallyIgnoreExtension)
+        return ignoredCodes == null
+                || ignoredCodes !is Iterable<*>
+                || code !in ignoredCodes.map { it.toString() }
+    }
+
     abstract fun validate(swagger: Swagger): Violation?
 
 }

--- a/server/src/main/java/de/zalando/zally/rule/SwaggerRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SwaggerRule.kt
@@ -4,13 +4,6 @@ import io.swagger.models.Swagger
 
 abstract class SwaggerRule : AbstractRule() {
 
-    fun accepts(swagger: Swagger): Boolean {
-        val ignoredCodes = swagger.vendorExtensions?.get(zallyIgnoreExtension)
-        return ignoredCodes == null
-                || ignoredCodes !is Iterable<*>
-                || code !in ignoredCodes.map { it.toString() }
-    }
-
     abstract fun validate(swagger: Swagger): Violation?
 
 }

--- a/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
@@ -10,8 +10,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 class SwaggerRulesValidator(@Autowired rules: List<SwaggerRule>,
-                            @Autowired rulesPolicy: RulesPolicy,
-                            @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<SwaggerRule>(rules, rulesPolicy, invalidApiRule) {
+                            @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<SwaggerRule>(rules, invalidApiRule) {
 
     @Throws(java.lang.Exception::class)
     override fun createRuleChecker(swaggerContent: String): (SwaggerRule) -> Iterable<Violation> {

--- a/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
@@ -1,5 +1,6 @@
 package de.zalando.zally.rule
 
+import com.fasterxml.jackson.databind.JsonNode
 import io.swagger.parser.SwaggerParser
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -13,11 +14,10 @@ class SwaggerRulesValidator(@Autowired rules: List<SwaggerRule>,
                             @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<SwaggerRule>(rules, invalidApiRule) {
 
     @Throws(java.lang.Exception::class)
-    override fun createRuleChecker(swaggerContent: String): (SwaggerRule) -> Iterable<Violation> {
-        val swagger = SwaggerParser().parse(swaggerContent)!!
+    override fun createRuleChecker(json: JsonNode): (SwaggerRule) -> Iterable<Violation> {
+        val swagger = SwaggerParser().read(json)!!
         return {
-            if (it.accepts(swagger)) listOfNotNull(it.validate(swagger))
-            else emptyList()
+            listOfNotNull(it.validate(swagger))
         }
     }
 

--- a/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
+++ b/server/src/main/java/de/zalando/zally/rule/SwaggerRulesValidator.kt
@@ -1,6 +1,5 @@
 package de.zalando.zally.rule
 
-import com.fasterxml.jackson.databind.JsonNode
 import io.swagger.parser.SwaggerParser
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -14,10 +13,11 @@ class SwaggerRulesValidator(@Autowired rules: List<SwaggerRule>,
                             @Autowired invalidApiRule: InvalidApiSchemaRule) : RulesValidator<SwaggerRule>(rules, invalidApiRule) {
 
     @Throws(java.lang.Exception::class)
-    override fun createRuleChecker(json: JsonNode): (SwaggerRule) -> Iterable<Violation> {
-        val swagger = SwaggerParser().read(json)!!
+    override fun createRuleChecker(swaggerContent: String): (SwaggerRule) -> Iterable<Violation> {
+        val swagger = SwaggerParser().parse(swaggerContent)!!
         return {
-            listOfNotNull(it.validate(swagger))
+            if (it.accepts(swagger)) listOfNotNull(it.validate(swagger))
+            else emptyList()
         }
     }
 

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
@@ -7,7 +7,6 @@ import de.zalando.zally.rule.CompositeRulesValidator;
 import de.zalando.zally.rule.InvalidApiSchemaRule;
 import de.zalando.zally.rule.JsonRule;
 import de.zalando.zally.rule.JsonRulesValidator;
-import de.zalando.zally.rule.RulesPolicy;
 import de.zalando.zally.rule.SwaggerRule;
 import de.zalando.zally.rule.SwaggerRulesValidator;
 import de.zalando.zally.rule.Violation;
@@ -26,9 +25,6 @@ import java.util.List;
 public class RestApiTestConfiguration {
 
     @Autowired
-    private RulesPolicy rulesPolicy;
-
-    @Autowired
     private InvalidApiSchemaRule invalidApiRule;
 
     @Bean
@@ -40,8 +36,8 @@ public class RestApiTestConfiguration {
             new AlwaysGiveAHintRule()
         );
         return new CompositeRulesValidator(
-                new SwaggerRulesValidator(rules, rulesPolicy, invalidApiRule),
-                new JsonRulesValidator(Arrays.asList(new CheckApiNameIsPresentJsonRule()), rulesPolicy, invalidApiRule));
+                new SwaggerRulesValidator(rules, invalidApiRule),
+                new JsonRulesValidator(Arrays.asList(new CheckApiNameIsPresentJsonRule()), invalidApiRule));
     }
 
     private static  class CheckApiNameIsPresentJsonRule extends  JsonRule{

--- a/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
@@ -19,14 +19,25 @@ class RulesPolicyTest {
     @Test
     fun shouldAcceptRuleIfNotFiltered() {
         val policy = RulesPolicy(arrayOf("M001", "M002"))
-        val violation = Violation(TestRule(null), "dummy1", "dummy", ViolationType.MUST, "dummy", listOf("x"))
-        assertTrue(policy.accepts(TestRule(violation)))
+        assertTrue(policy.accepts(TestRule(null)))
     }
 
     @Test
     fun shouldNotAcceptRuleIfFiltered() {
         val policy = RulesPolicy(arrayOf("M001", "M999"))
-        val violation = Violation(TestRule(null), "dummy1", "dummy", ViolationType.MUST, "dummy", listOf("x"))
-        assertFalse(policy.accepts(TestRule(violation)))
+        assertFalse(policy.accepts(TestRule(null)))
+    }
+
+    @Test
+    fun withMoreIgnoresAllowsExtension() {
+
+        val original = RulesPolicy(emptyArray())
+        assertTrue(original.accepts(TestRule(null)))
+
+        val extended = original.withMoreIgnores(listOf("M001", "M999"))
+        assertFalse(extended.accepts(TestRule(null)))
+
+        // original is unmodified
+        assertTrue(original.accepts(TestRule(null)))
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
@@ -37,37 +37,37 @@ class RulesValidatorTest {
 
     @Test
     fun shouldReturnEmptyViolationsListWithoutRules() {
-        val validator = SwaggerRulesValidator(emptyList(), RulesPolicy(emptyArray()), invalidApiSchemaRule)
-        assertThat(validator.validate(swaggerContent)).isEmpty()
+        val validator = SwaggerRulesValidator(emptyList(), invalidApiSchemaRule)
+        assertThat(validator.validate(swaggerContent, RulesPolicy(emptyArray()))).isEmpty()
     }
 
     @Test
     fun shouldReturnOneViolation() {
         val violations = listOf(DUMMY_VIOLATION_1)
-        val validator = SwaggerRulesValidator(getRules(violations), RulesPolicy(emptyArray()), invalidApiSchemaRule)
-        assertThat(validator.validate(swaggerContent)).hasSameElementsAs(violations)
+        val validator = SwaggerRulesValidator(getRules(violations), invalidApiSchemaRule)
+        assertThat(validator.validate(swaggerContent, RulesPolicy(emptyArray()))).hasSameElementsAs(violations)
     }
 
     @Test
     fun shouldCollectViolationsOfAllRules() {
         val violations = listOf(DUMMY_VIOLATION_1, DUMMY_VIOLATION_2)
-        val validator = SwaggerRulesValidator(getRules(violations), RulesPolicy(emptyArray()), invalidApiSchemaRule)
-        assertThat(validator.validate(swaggerContent)).hasSameElementsAs(violations)
+        val validator = SwaggerRulesValidator(getRules(violations), invalidApiSchemaRule)
+        assertThat(validator.validate(swaggerContent, RulesPolicy(emptyArray()))).hasSameElementsAs(violations)
     }
 
     @Test
     fun shouldSortViolationsByViolationType() {
         val violations = listOf(DUMMY_VIOLATION_1, DUMMY_VIOLATION_2, DUMMY_VIOLATION_3)
-        val validator = SwaggerRulesValidator(getRules(violations), RulesPolicy(emptyArray()), invalidApiSchemaRule)
-        assertThat(validator.validate(swaggerContent))
+        val validator = SwaggerRulesValidator(getRules(violations), invalidApiSchemaRule)
+        assertThat(validator.validate(swaggerContent, RulesPolicy(emptyArray())))
                 .containsExactly(DUMMY_VIOLATION_3, DUMMY_VIOLATION_1, DUMMY_VIOLATION_2)
     }
 
     @Test
     fun shouldIgnoreSpecifiedRules() {
         val violations = listOf(DUMMY_VIOLATION_1, DUMMY_VIOLATION_2, DUMMY_VIOLATION_3)
-        val validator = SwaggerRulesValidator(getRules(violations), RulesPolicy(arrayOf("M999")), invalidApiSchemaRule)
-        assertThat(validator.validate(swaggerContent)).containsExactly(DUMMY_VIOLATION_1, DUMMY_VIOLATION_2)
+        val validator = SwaggerRulesValidator(getRules(violations), invalidApiSchemaRule)
+        assertThat(validator.validate(swaggerContent, RulesPolicy(arrayOf("M999")))).containsExactly(DUMMY_VIOLATION_1, DUMMY_VIOLATION_2)
     }
 
     @Test
@@ -78,8 +78,8 @@ class RulesValidatorTest {
         Mockito.`when`(resultRule.violationType).thenReturn(ViolationType.MUST)
         Mockito.`when`(resultRule.url).thenReturn("url")
 
-        val validator = SwaggerRulesValidator(emptyList(), RulesPolicy(emptyArray()), resultRule)
-        val valResult = validator.validate("Invalid swagger content !@##")
+        val validator = SwaggerRulesValidator(emptyList(), resultRule)
+        val valResult = validator.validate("Invalid swagger content !@##", RulesPolicy(emptyArray()))
         assertThat(valResult).hasSize(1)
         assertThat(valResult[0].title).isEqualTo(resultRule.title)
     }


### PR DESCRIPTION
* ViolationsApiController now aware of the configured RulesPolicy
* ViolationsApiController passes a modified RulesPolicy to ApiValidator rather than the request-time list of ignores
* ApiValidators use request level RulesPolicy passed into the method rather than config level RulesPolicy in the constructor 
* RulesValidator now extracts x-zally-ignores from documents rather than the rule implementations themselves
* RulesValidator uses a RulesPolicy (modified with any x-zally-ignores additions) to decide which rules to use.

Should make #558 easier to implement and edges my #559 plans forward too.