### PR TITLE
Violation related tests focus on description and paths properties

### DIFF
--- a/server/src/main/java/de/zalando/zally/rule/zalando/QueryParameterCollectionFormatRule.kt
+++ b/server/src/main/java/de/zalando/zally/rule/zalando/QueryParameterCollectionFormatRule.kt
@@ -15,7 +15,7 @@ class QueryParameterCollectionFormatRule(@Autowired ruleSet: ZalandoRuleSet) : A
     override val violationType = ViolationType.SHOULD
     override val id = "154"
     val formatsAllowed = listOf("csv", "multi")
-    val violationDescription = "CollectionFormat should be one of: {formatsAllowed}"
+    val violationDescription = "CollectionFormat should be one of: $formatsAllowed"
 
     @Check
     fun validate(swagger: Swagger): Violation? {

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiIgnoreRulesTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiIgnoreRulesTest.java
@@ -2,6 +2,7 @@ package de.zalando.zally.apireview;
 
 import de.zalando.zally.dto.ApiDefinitionResponse;
 import de.zalando.zally.dto.ViolationDTO;
+import org.assertj.core.groups.Tuple;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
 
@@ -10,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import static de.zalando.zally.util.ResourceUtil.readApiDefinition;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @TestPropertySource(properties = "zally.ignoreRules=H999")
@@ -20,9 +22,12 @@ public class RestApiIgnoreRulesTest extends RestApiBaseTest {
         ApiDefinitionResponse response = sendApiDefinition(readApiDefinition("fixtures/api_spp.json"));
 
         List<ViolationDTO> violations = response.getViolations();
-        assertThat(violations).hasSize(2);
-        assertThat(violations.get(0).getTitle()).isEqualTo("dummy1");
-        assertThat(violations.get(1).getTitle()).isEqualTo("schema");
+        assertThat(violations)
+                .extracting("description","paths")
+                .containsExactly(
+                        new Tuple("dummy1", emptyList()),
+                        new Tuple("schema incorrect", emptyList())
+                );
 
         Map<String, Integer> count = response.getViolationsCount();
         assertThat(count.get("must")).isEqualTo(2);

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiTestConfiguration.java
@@ -63,7 +63,7 @@ public class RestApiTestConfiguration {
 
         @Override
         public String getTitle() {
-            return "schema";
+            return getClass().getSimpleName();
         }
 
         @Override
@@ -90,7 +90,7 @@ public class RestApiTestConfiguration {
         @Check
         public Violation validate(Swagger swagger) {
             if (swagger != null && swagger.getInfo().getTitle().contains(apiName)) {
-                return new Violation(new CheckApiNameIsPresentRule(null), "dummy1", "dummy", ViolationType.MUST, Collections.emptyList());
+                return new Violation(this, getTitle(), "dummy1", ViolationType.MUST, Collections.emptyList());
             } else {
                 return null;
             }
@@ -103,7 +103,7 @@ public class RestApiTestConfiguration {
 
         @Override
         public String getTitle() {
-            return "Test Rule";
+            return getClass().getSimpleName();
         }
 
         @Override
@@ -120,9 +120,7 @@ public class RestApiTestConfiguration {
 
         @Check
         public Violation validate(Swagger swagger) {
-            return new Violation(
-                new AlwaysGiveAHintRule(),
-                "dummy2", "dummy", ViolationType.HINT, Collections.emptyList());
+            return new Violation(this, getTitle(), "dummy2", ViolationType.HINT, Collections.emptyList());
         }
 
         @Override
@@ -132,7 +130,7 @@ public class RestApiTestConfiguration {
 
         @Override
         public String getTitle() {
-            return "Test Hint Rule";
+            return getClass().getSimpleName();
         }
 
         @Override

--- a/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
+++ b/server/src/test/java/de/zalando/zally/apireview/RestApiViolationsTest.java
@@ -62,9 +62,9 @@ public class RestApiViolationsTest extends RestApiBaseTest {
 
         List<ViolationDTO> violations = response.getViolations();
         assertThat(violations).hasSize(3);
-        assertThat(violations.get(0).getTitle()).isEqualTo("dummy1");
-        assertThat(violations.get(1).getTitle()).isEqualTo("dummy2");
-        assertThat(violations.get(2).getTitle()).isEqualTo("schema");
+        assertThat(violations.get(0).getTitle()).isEqualTo("CheckApiNameIsPresentRule");
+        assertThat(violations.get(1).getTitle()).isEqualTo("AlwaysGiveAHintRule");
+        assertThat(violations.get(2).getTitle()).isEqualTo("CheckApiNameIsPresentJsonRule");
     }
 
     @Test
@@ -95,7 +95,7 @@ public class RestApiViolationsTest extends RestApiBaseTest {
 
         List<ViolationDTO> violations = response.getViolations();
         assertThat(violations).hasSize(1);
-        assertThat(violations.get(0).getTitle()).isEqualTo("dummy2");
+        assertThat(violations.get(0).getTitle()).isEqualTo("AlwaysGiveAHintRule");
     }
 
     @Test
@@ -106,7 +106,7 @@ public class RestApiViolationsTest extends RestApiBaseTest {
 
         List<ViolationDTO> violations = response.getViolations();
         assertThat(violations).hasSize(1);
-        assertThat(violations.get(0).getTitle()).isEqualTo("dummy2");
+        assertThat(violations.get(0).getTitle()).isEqualTo("AlwaysGiveAHintRule");
     }
 
     @Test
@@ -155,8 +155,8 @@ public class RestApiViolationsTest extends RestApiBaseTest {
         ).getViolations();
 
         assertThat(violations).hasSize(3);
-        assertThat(violations.get(0).getTitle()).isEqualTo("dummy1");
-        assertThat(violations.get(1).getTitle()).isEqualTo("dummy2");
+        assertThat(violations.get(0).getTitle()).isEqualTo("CheckApiNameIsPresentRule");
+        assertThat(violations.get(1).getTitle()).isEqualTo("AlwaysGiveAHintRule");
     }
 
     @Test
@@ -168,7 +168,7 @@ public class RestApiViolationsTest extends RestApiBaseTest {
         ).getViolations();
 
         assertThat(violations).hasSize(1);
-        assertThat(violations.get(0).getTitle()).isEqualTo("dummy2");
+        assertThat(violations.get(0).getTitle()).isEqualTo("AlwaysGiveAHintRule");
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/RestSupportedRulesTest.java
+++ b/server/src/test/java/de/zalando/zally/rule/RestSupportedRulesTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,10 +62,26 @@ public class RestSupportedRulesTest extends RestApiBaseTest {
 
     @Test
     public void testFilterByType() {
-        for (ViolationType ruleType : ViolationType.values()) {
-            assertFilteredByRuleType(ruleType.toString());
-            assertFilteredByRuleType(ruleType.toString().toLowerCase());
-        }
+
+        final int expectedCount = implementedRules.size();
+
+        final int mustCount = getSupportedRules("MuSt", null).size();
+        assertThat(mustCount).isLessThan(expectedCount);
+
+        final int shouldCount = getSupportedRules("ShOuLd", null).size();
+        assertThat(shouldCount).isLessThan(expectedCount);
+
+        final int mayCount = getSupportedRules("MaY", null).size();
+        assertThat(mayCount).isLessThan(expectedCount);
+
+        final int couldCount = getSupportedRules("CoUlD", null).size();
+        assertThat(couldCount).isLessThan(expectedCount);
+
+        final int hintCount = getSupportedRules("HiNt", null).size();
+        assertThat(hintCount).isLessThan(expectedCount);
+
+        final int actualCount = mustCount + shouldCount + mayCount + couldCount + hintCount;
+        assertThat(actualCount).isEqualTo(expectedCount);
     }
 
     @Test
@@ -90,19 +105,5 @@ public class RestSupportedRulesTest extends RestApiBaseTest {
     public void testFilterByActiveFalse() {
         List<RuleDTO> rules = getSupportedRules(null, false);
         assertThat(rules.size()).isEqualTo(IGNORED_RULES.size());
-    }
-
-    private void assertFilteredByRuleType(String ruleType) throws AssertionError {
-        List<RuleDTO> rules = getSupportedRules(ruleType, null);
-        List<Rule> expectedRules = getRulesByType(ViolationType.valueOf(ruleType.toUpperCase()));
-
-        assertThat(rules.size()).isEqualTo(expectedRules.size());
-    }
-
-    private List<Rule> getRulesByType(ViolationType violationType) {
-        return implementedRules
-            .stream()
-            .filter(r -> r.getViolationType() == violationType)
-            .collect(Collectors.toList());
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/AvoidLinkHeadersRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/AvoidLinkHeadersRuleTest.kt
@@ -1,6 +1,5 @@
 package de.zalando.zally.rule.zalando
 
-import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.getFixture
 import de.zalando.zally.testConfig
 import org.assertj.core.api.Assertions.assertThat
@@ -26,7 +25,6 @@ class AvoidLinkHeadersRuleTest {
     fun negativeCase() {
         val swagger = getFixture("avoidLinkHeaderRuleInvalid.json")
         val violation = rule.validate(swagger)!!
-        assertThat(violation.violationType).isEqualTo(ViolationType.MUST)
         assertThat(violation.paths).hasSameElementsAs(
             listOf("/product-put-requests/{product_path} Link", "/products Link"))
 

--- a/server/src/test/java/de/zalando/zally/rule/zalando/EverySecondPathLevelParameterRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/EverySecondPathLevelParameterRuleTest.kt
@@ -1,6 +1,5 @@
 package de.zalando.zally.rule.zalando
 
-import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.getFixture
 import de.zalando.zally.swaggerWithPaths
 import org.assertj.core.api.Assertions.assertThat
@@ -29,7 +28,6 @@ class EverySecondPathLevelParameterRuleTest {
             "/{merchant_id}",
             "/{parcel_id}/info/{update-group}")
         val result = rule.validate(swagger)!!
-        assertThat(result.violationType).isEqualTo(ViolationType.MUST)
         assertThat(result.paths).hasSameElementsAs(listOf(
             "/api/some/{param-1}/path/",
             "/another/{param-0}/{param-1}",

--- a/server/src/test/java/de/zalando/zally/rule/zalando/ExtensibleEnumRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/ExtensibleEnumRuleTest.kt
@@ -1,8 +1,6 @@
 package de.zalando.zally.rule.zalando
 
-import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.getFixture
-import de.zalando.zally.rule.Violation
 import io.swagger.models.Swagger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -19,32 +17,25 @@ class ExtensibleEnumRuleTest {
     @Test
     fun returnsViolationIfAnEnumInModelProperty() {
         val swagger = getFixture("enum_in_model_property.yaml")
-        val expectedViolation = Violation(rule = rule,
-                title = rule.title,
-                violationType = ViolationType.SHOULD,
-                description = "Properties/Parameters [status] are not extensible enums",
-                paths = listOf("#/definitions/CrawledAPIDefinition/properties/status"))
 
         val violation = rule.validate(swagger)
 
-        assertThat(violation).isNotNull()
-        assertThat(violation).isEqualTo(expectedViolation)
+        assertThat(violation)
+                .hasFieldOrPropertyWithValue("description", "Properties/Parameters [status] are not extensible enums")
+                .hasFieldOrPropertyWithValue("paths", listOf("#/definitions/CrawledAPIDefinition/properties/status"))
     }
 
     @Test
     fun returnsViolationIfAnEnumInRequestParameter() {
         val swagger = getFixture("enum_in_request_parameter.yaml")
-        val expectedViolation = Violation(rule = rule,
-                title = rule.title,
-                violationType = ViolationType.SHOULD,
-                description = "Properties/Parameters [lifecycle_state, environment] are not extensible enums",
-                paths = listOf("#/paths/apis/{api_id}/versions/GET/parameters/lifecycle_state",
-                        "#/paths/apis/GET/parameters/environment"))
 
         val violation = rule.validate(swagger)
 
-        assertThat(violation).isNotNull()
-        assertThat(violation).isEqualTo(expectedViolation)
+        assertThat(violation)
+                .hasFieldOrPropertyWithValue("description", "Properties/Parameters [lifecycle_state, environment] are not extensible enums")
+                .hasFieldOrPropertyWithValue("paths", listOf(
+                        "#/paths/apis/{api_id}/versions/GET/parameters/lifecycle_state",
+                        "#/paths/apis/GET/parameters/environment"))
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zalando/NoVersionInUriRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/NoVersionInUriRuleTest.kt
@@ -1,7 +1,5 @@
 package de.zalando.zally.rule.zalando
 
-import de.zalando.zally.dto.ViolationType
-import de.zalando.zally.rule.Violation
 import io.swagger.models.Swagger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -10,35 +8,36 @@ class NoVersionInUriRuleTest {
 
     private val rule = NoVersionInUriRule(ZalandoRuleSet())
 
-    val expectedViolation = Violation(
-            rule,
-            "Do Not Use URI Versioning",
-            "basePath attribute contains version number",
-            ViolationType.MUST,
-            emptyList())
-
     @Test
     fun returnsViolationsWhenVersionIsInTheBeginingOfBasePath() {
         val swagger = Swagger().apply { basePath = "/v1/tests" }
-        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger))
+                .hasFieldOrPropertyWithValue("description", "basePath attribute contains version number")
+                .hasFieldOrPropertyWithValue("paths", listOf<String>())
     }
 
     @Test
     fun returnsViolationsWhenVersionIsInTheMiddleOfBasePath() {
         val swagger = Swagger().apply { basePath = "/api/v1/tests" }
-        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger))
+                .hasFieldOrPropertyWithValue("description", "basePath attribute contains version number")
+                .hasFieldOrPropertyWithValue("paths", listOf<String>())
     }
 
     @Test
     fun returnsViolationsWhenVersionIsInTheEndOfBasePath() {
         val swagger = Swagger().apply { basePath = "/api/v1" }
-        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger))
+                .hasFieldOrPropertyWithValue("description", "basePath attribute contains version number")
+                .hasFieldOrPropertyWithValue("paths", listOf<String>())
     }
 
     @Test
     fun returnsViolationsWhenVersionIsBig() {
         val swagger = Swagger().apply { basePath = "/v1024/tests" }
-        assertThat(rule.validate(swagger)).isEqualTo(expectedViolation)
+        assertThat(rule.validate(swagger))
+                .hasFieldOrPropertyWithValue("description", "basePath attribute contains version number")
+                .hasFieldOrPropertyWithValue("paths", listOf<String>())
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zalando/QueryParameterCollectionFormatRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/QueryParameterCollectionFormatRuleTest.kt
@@ -1,6 +1,5 @@
 package de.zalando.zally.rule.zalando
 
-import de.zalando.zally.dto.ViolationType
 import io.swagger.models.Operation
 import io.swagger.models.Path
 import io.swagger.models.Swagger
@@ -19,8 +18,9 @@ class QueryParameterCollectionFormatRuleTest {
         }
 
         val result = rule.validate(swagger)!!
-        assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
-        assertThat(result.rule.id).isEqualTo("154")
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("description", "CollectionFormat should be one of: [csv, multi]")
+                .hasFieldOrPropertyWithValue("paths", listOf("parameters test"))
     }
 
     @Test
@@ -31,8 +31,9 @@ class QueryParameterCollectionFormatRuleTest {
         }
 
         val result = rule.validate(swagger)!!
-        assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
-        assertThat(result.rule.id).isEqualTo("154")
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("description", "CollectionFormat should be one of: [csv, multi]")
+                .hasFieldOrPropertyWithValue("paths", listOf("/apis test"))
     }
 
     @Test
@@ -42,8 +43,9 @@ class QueryParameterCollectionFormatRuleTest {
         }
 
         val result = rule.validate(swagger)!!
-        assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
-        assertThat(result.rule.id).isEqualTo("154")
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("description", "CollectionFormat should be one of: [csv, multi]")
+                .hasFieldOrPropertyWithValue("paths", listOf("parameters test"))
     }
 
     @Test
@@ -54,8 +56,9 @@ class QueryParameterCollectionFormatRuleTest {
         }
 
         val result = rule.validate(swagger)!!
-        assertThat(result.violationType).isEqualTo(ViolationType.SHOULD)
-        assertThat(result.rule.id).isEqualTo("154")
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("description", "CollectionFormat should be one of: [csv, multi]")
+                .hasFieldOrPropertyWithValue("paths", listOf("/apis test"))
     }
 
     @Test
@@ -95,5 +98,4 @@ class QueryParameterCollectionFormatRuleTest {
 
         assertThat(rule.validate(swagger)).isNull()
     }
-
 }

--- a/server/src/test/java/de/zalando/zally/rule/zalando/SecureWithOAuth2RuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zalando/SecureWithOAuth2RuleTest.kt
@@ -1,8 +1,6 @@
 package de.zalando.zally.rule.zalando
 
-import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.getFixture
-import de.zalando.zally.rule.Violation
 import io.swagger.models.Scheme
 import io.swagger.models.Swagger
 import io.swagger.models.auth.ApiKeyAuthDefinition
@@ -15,30 +13,10 @@ class SecureWithOAuth2RuleTest {
 
     private val rule = SecureWithOAuth2Rule(ZalandoRuleSet())
 
-    private val checkSecurityDefinitionsExpectedOauthViolation = Violation(
-            rule,
-            "Secure Endpoints with OAuth 2.0",
-            "No OAuth2 security definitions found",
-            ViolationType.MUST,
-            emptyList())
-
-    private val checkSecurityDefinitionsExpectedHttpsViolation = Violation(
-            rule,
-            "Secure Endpoints with OAuth 2.0",
-            "OAuth2 should be only used together with https",
-            ViolationType.MUST,
-            emptyList())
-
-    private val checkPasswordFlowExpectedViolation = Violation(
-            rule,
-            "Set Flow to Password When Using OAuth 2.0",
-            "OAuth2 security definitions should use password flow",
-            ViolationType.SHOULD,
-            emptyList())
-
     @Test
     fun checkSecurityDefinitionsWithEmptyReturnsViolation() {
-        assertThat(rule.checkSecurityDefinitions(Swagger())).isEqualTo(checkSecurityDefinitionsExpectedOauthViolation)
+        assertThat(rule.checkSecurityDefinitions(Swagger()))
+                .hasFieldOrPropertyWithValue("description", "No OAuth2 security definitions found")
     }
 
     @Test
@@ -46,7 +24,8 @@ class SecureWithOAuth2RuleTest {
         val swagger = Swagger().apply {
             securityDefinitions = emptyMap()
         }
-        assertThat(rule.checkSecurityDefinitions(swagger)).isEqualTo(checkSecurityDefinitionsExpectedOauthViolation)
+        assertThat(rule.checkSecurityDefinitions(swagger))
+                .hasFieldOrPropertyWithValue("description", "No OAuth2 security definitions found")
     }
 
     @Test
@@ -57,7 +36,8 @@ class SecureWithOAuth2RuleTest {
                 "ApiKey" to ApiKeyAuthDefinition()
             )
         }
-        assertThat(rule.checkSecurityDefinitions(swagger)).isEqualTo(checkSecurityDefinitionsExpectedOauthViolation)
+        assertThat(rule.checkSecurityDefinitions(swagger))
+                .hasFieldOrPropertyWithValue("description", "No OAuth2 security definitions found")
     }
 
     @Test
@@ -68,7 +48,8 @@ class SecureWithOAuth2RuleTest {
                     "Oauth2" to OAuth2Definition()
             )
         }
-        assertThat(rule.checkSecurityDefinitions(swagger)).isEqualTo(checkSecurityDefinitionsExpectedHttpsViolation)
+        assertThat(rule.checkSecurityDefinitions(swagger))
+                .hasFieldOrPropertyWithValue("description", "OAuth2 should be only used together with https")
     }
 
     @Test
@@ -152,7 +133,8 @@ class SecureWithOAuth2RuleTest {
                     }
             )
         }
-        assertThat(rule.checkPasswordFlow(swagger)).isEqualTo(checkPasswordFlowExpectedViolation)
+        assertThat(rule.checkPasswordFlow(swagger))
+                .hasFieldOrPropertyWithValue("description", "OAuth2 security definitions should use password flow")
     }
 
     @Test
@@ -163,7 +145,8 @@ class SecureWithOAuth2RuleTest {
                     "Oauth2" to OAuth2Definition()
             )
         }
-        assertThat(rule.checkPasswordFlow(swagger)).isEqualTo(checkPasswordFlowExpectedViolation)
+        assertThat(rule.checkPasswordFlow(swagger))
+                .hasFieldOrPropertyWithValue("description", "OAuth2 security definitions should use password flow")
     }
 
     @Test
@@ -176,6 +159,7 @@ class SecureWithOAuth2RuleTest {
                     }
             )
         }
-        assertThat(rule.checkPasswordFlow(swagger)).isEqualTo(checkPasswordFlowExpectedViolation)
+        assertThat(rule.checkPasswordFlow(swagger))
+                .hasFieldOrPropertyWithValue("description", "OAuth2 security definitions should use password flow")
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/ExtractBasePathRuleTest.kt
@@ -1,8 +1,6 @@
 package de.zalando.zally.rule.zally
 
-import de.zalando.zally.dto.ViolationType
 import de.zalando.zally.getFixture
-import de.zalando.zally.rule.Violation
 import de.zalando.zally.swaggerWithPaths
 import io.swagger.models.Swagger
 import org.assertj.core.api.Assertions.assertThat
@@ -37,10 +35,9 @@ class ExtractBasePathRuleTest {
             "/shipment/{shipment_id}/status",
             "/shipment/{shipment_id}/details"
         )
-        val rule = rule
-        val expected = Violation(rule, rule.title, DESC_PATTERN.format("/shipment"),
-                ViolationType.HINT, emptyList())
-        assertThat(rule.validate(swagger)).isEqualTo(expected)
+        assertThat(rule.validate(swagger))
+                .hasFieldOrPropertyWithValue("description", DESC_PATTERN.format("/shipment"))
+                .hasFieldOrPropertyWithValue("paths", listOf<String>())
     }
 
     @Test
@@ -51,10 +48,9 @@ class ExtractBasePathRuleTest {
             "/queue/models/{model-id}",
             "/queue/models/summaries"
         )
-        val rule = rule
-        val expected = Violation(rule, rule.title, DESC_PATTERN.format("/queue/models"),
-                ViolationType.HINT, emptyList())
-        assertThat(rule.validate(swagger)).isEqualTo(expected)
+        assertThat(rule.validate(swagger))
+                .hasFieldOrPropertyWithValue("description", DESC_PATTERN.format("/queue/models"))
+                .hasFieldOrPropertyWithValue("paths", listOf<String>())
     }
 
     @Test

--- a/server/src/test/java/de/zalando/zally/rule/zally/NoProtocolInHostRuleTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/zally/NoProtocolInHostRuleTest.kt
@@ -30,14 +30,18 @@ class NoProtocolInHostRuleTest {
     fun negativeCaseHttp() {
         val swagger = Swagger().apply { host = "http://google.com" }
         val res = rule.validate(swagger)
-        assertThat(res?.copy(description = "")).isEqualTo(expectedViolation)
+        assertThat(res)
+                .hasFieldOrPropertyWithValue("description", "Information about protocol should be placed in schema. Current host value 'http://google.com' violates this rule")
+                .hasFieldOrPropertyWithValue("paths", listOf<String>())
     }
 
     @Test
     fun negativeCaseHttps() {
         val swagger = Swagger().apply { host = "https://google.com" }
         val res = rule.validate(swagger)
-        assertThat(res?.copy(description = "")).isEqualTo(expectedViolation)
+        assertThat(res)
+                .hasFieldOrPropertyWithValue("description", "Information about protocol should be placed in schema. Current host value 'https://google.com' violates this rule")
+                .hasFieldOrPropertyWithValue("paths", listOf<String>())
     }
 
     @Test


### PR DESCRIPTION
* Corrected QueryParameterCollectionFormatRule description
* Rule related tests avoid focusing on violation type
* TestRules now construct Violations using rule title

(All in preparation for simplifying Violation creation to just using description and path properties.)