### PR TITLE
#600 bump kotlin version

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,7 +8,7 @@ def versions = [
 
 buildscript {
 
-    ext.kotlin_version = '1.1.51'
+    ext.kotlin_version = '1.2.0'
 
     repositories {
         mavenCentral()
@@ -70,15 +70,12 @@ dependencies {
     compile("com.fasterxml.jackson.module:jackson-module-parameter-names")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
-    compile("com.fasterxml.jackson.module:jackson-module-kotlin") {
-        exclude group: "org.jetbrains.kotlin", module: "kotlin-reflect"
-    }
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin")
     compile("org.zalando.stups:stups-spring-oauth2-server:1.0.19")
     compile("org.zalando:problem-spring-web:0.22.0")
     compile("org.zalando:twintip-spring-web:1.1.0")
     compile("org.zalando.zmon:zmon-actuator:0.9.7")
     compile("io.dropwizard.metrics:metrics-core:3.2.2")
-    compile("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
     compile("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
     compile("com.typesafe:config:1.3.2")
 


### PR DESCRIPTION
Closes #600 

I don't really get why we excluded kotlin-reflect from jackson and declare explicit dependency on it.
But apparently it doesn't work with this setup so I had to change it.