### PR TITLE
Remove unsupported header `X-App-Domain`

### DIFF
--- a/server/src/main/resources/rules-config.conf
+++ b/server/src/main/resources/rules-config.conf
@@ -259,7 +259,6 @@ ProprietaryHeadersRule {
     "X-Device-Type",
     "X-Device-OS",
     "X-Mobile-Advertising-ID",
-    "X-App-Domain",
     "X-RateLimit-Limit",
     "X-RateLimit-Remaining",
     "X-RateLimit-Reset"


### PR DESCRIPTION
Remove `X-App-Domain` header which is not supported anymore by [Zalando API Guidelines](https://opensource.zalando.com/restful-api-guidelines/#183).

Resolves: #723