### PR TITLE
Fix: #1083. Enable customizing the ZALLY_API_URL via docker-compose.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,17 @@
+#
+# To run this container on a public URL
+# you should pass the ZALLY_API_URL environment
+# variable to docker-compose, referencing the external
+# URL of the Zally API.
+#
+# $ ZALLY_API_URL=http://157.230.116.206:8000 docker-compose up
+#
 version: '2.1'
 services:
   web-ui:
     build: ./web-ui
+    environment:
+    - ZALLY_API_URL=${ZALLY_API_URL:-http://localhost:8000}
     depends_on:
     - server
     links:


### PR DESCRIPTION
## This PR

Simplifies running zally on a docker machine and/or for development purposes
enabling the following command

```
ZALLY_API_URL=http://157.230.116.206:8000 docker-compose up
```

## Note

The basic workflow remains unchanged.