### PR TITLE
Remove `spring` dependency from `RulesPolicy`

### DIFF
--- a/cli/zally/integration_test.go
+++ b/cli/zally/integration_test.go
@@ -82,9 +82,9 @@ func TestIntegrationWithNoMustViolations(t *testing.T) {
 	must, should, may, hint := countViolations(out)
 
 	assert.Zero(t, must, "No MUST violations expected")
-	assert.True(t, should == 0, "No SHOULD violation expected")
+	assert.Zero(t, should, "No SHOULD violation expected")
 	assert.True(t, may > 0, "At least one MAY violation expected")
-	assert.Equal(t, 0, hint)
+	assert.Zero(t, hint)
 	assert.Nil(t, e)
 }
 

--- a/server/src/main/java/de/zalando/zally/configuration/ConversionServiceConfiguration.kt
+++ b/server/src/main/java/de/zalando/zally/configuration/ConversionServiceConfiguration.kt
@@ -1,0 +1,15 @@
+package de.zalando.zally.configuration
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.ConversionService
+import org.springframework.core.convert.support.DefaultConversionService
+
+@Configuration
+class ConversionServiceConfiguration {
+
+    @Bean
+    fun conversionService(): ConversionService {
+        return DefaultConversionService()
+    }
+}

--- a/server/src/main/java/de/zalando/zally/configuration/RulesPolicyConfiguration.kt
+++ b/server/src/main/java/de/zalando/zally/configuration/RulesPolicyConfiguration.kt
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration
 class RulesPolicyConfiguration {
 
     @Value("\${zally.ignoreRules:}")
-    private lateinit var ignoredRules: Array<String>
+    private lateinit var ignoredRules: List<String>
 
     @Bean
     fun rulesPolicy(): RulesPolicy {

--- a/server/src/main/java/de/zalando/zally/configuration/RulesPolicyConfiguration.kt
+++ b/server/src/main/java/de/zalando/zally/configuration/RulesPolicyConfiguration.kt
@@ -1,0 +1,18 @@
+package de.zalando.zally.configuration
+
+import de.zalando.zally.rule.RulesPolicy
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RulesPolicyConfiguration {
+
+    @Value("\${zally.ignoreRules:}")
+    private lateinit var ignoredRules: Array<String>
+
+    @Bean
+    fun rulesPolicy(): RulesPolicy {
+        return RulesPolicy(ignoredRules)
+    }
+}

--- a/server/src/main/java/de/zalando/zally/rule/RulesPolicy.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesPolicy.kt
@@ -1,15 +1,27 @@
 package de.zalando.zally.rule
 
 import de.zalando.zally.rule.api.Rule
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Component
 
-@Component
-class RulesPolicy(@Value("\${zally.ignoreRules:}") val ignoreRules: Array<String>) {
+data class RulesPolicy(val ignoreRules: Array<String>) {
 
     fun accepts(rule: Rule): Boolean {
         return !ignoreRules.contains(rule.id)
     }
 
-    fun withMoreIgnores(moreIgnores: List<String>) = RulesPolicy(ignoreRules + moreIgnores)
+    fun withMoreIgnores(moreIgnores: List<String>) = this.copy(ignoreRules = ignoreRules + moreIgnores)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RulesPolicy
+
+        if (!ignoreRules.contentEquals(other.ignoreRules)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return ignoreRules.contentHashCode()
+    }
 }

--- a/server/src/main/java/de/zalando/zally/rule/RulesPolicy.kt
+++ b/server/src/main/java/de/zalando/zally/rule/RulesPolicy.kt
@@ -2,26 +2,10 @@ package de.zalando.zally.rule
 
 import de.zalando.zally.rule.api.Rule
 
-data class RulesPolicy(val ignoreRules: Array<String>) {
-
+data class RulesPolicy(val ignoreRules: List<String>) {
     fun accepts(rule: Rule): Boolean {
         return !ignoreRules.contains(rule.id)
     }
 
-    fun withMoreIgnores(moreIgnores: List<String>) = this.copy(ignoreRules = ignoreRules + moreIgnores)
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as RulesPolicy
-
-        if (!ignoreRules.contentEquals(other.ignoreRules)) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return ignoreRules.contentHashCode()
-    }
+    fun withMoreIgnores(moreIgnores: List<String>) = RulesPolicy(ignoreRules + moreIgnores)
 }

--- a/server/src/test/java/de/zalando/zally/rule/NullPointerExceptionTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/NullPointerExceptionTest.kt
@@ -434,6 +434,6 @@ class NullPointerExceptionTest(
 
     @Test
     fun `validate with spec does not throw NullPointerException`() {
-        validator.validate(spec, RulesPolicy(emptyArray()))
+        validator.validate(spec, RulesPolicy(emptyList()))
     }
 }

--- a/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesPolicyTest.kt
@@ -27,19 +27,19 @@ class RulesPolicyTest {
 
     @Test
     fun shouldAcceptRuleIfNotFiltered() {
-        val policy = RulesPolicy(arrayOf("TestCheckApiNameIsPresentJsonRule", "136"))
+        val policy = RulesPolicy(listOf("TestCheckApiNameIsPresentJsonRule", "136"))
         assertTrue(policy.accepts(rule()))
     }
 
     @Test
     fun shouldNotAcceptRuleIfFiltered() {
-        val policy = RulesPolicy(arrayOf("TestCheckApiNameIsPresentJsonRule", "TestRule"))
+        val policy = RulesPolicy(listOf("TestCheckApiNameIsPresentJsonRule", "TestRule"))
         assertFalse(policy.accepts(rule()))
     }
 
     @Test
     fun withMoreIgnoresAllowsExtension() {
-        val original = RulesPolicy(emptyArray())
+        val original = RulesPolicy(emptyList())
         assertTrue(original.accepts(rule()))
 
         val extended = original.withMoreIgnores(listOf("TestCheckApiNameIsPresentJsonRule", "TestRule"))

--- a/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
+++ b/server/src/test/java/de/zalando/zally/rule/RulesValidatorTest.kt
@@ -64,7 +64,7 @@ class RulesValidatorTest {
     fun shouldReturnEmptyViolationsListWithoutRules() {
         val rules = emptyList<Any>()
         val validator = SwaggerRulesValidator(rulesManager(rules))
-        val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
+        val results = validator.validate(swaggerContent, RulesPolicy(emptyList()))
         assertThat(results)
             .isEmpty()
     }
@@ -73,7 +73,7 @@ class RulesValidatorTest {
     fun shouldReturnOneViolation() {
         val rules = listOf(TestSecondRule())
         val validator = SwaggerRulesValidator(rulesManager(rules))
-        val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
+        val results = validator.validate(swaggerContent, RulesPolicy(emptyList()))
         assertThat(results.map(Result::description))
             .containsExactly("dummy3")
     }
@@ -82,7 +82,7 @@ class RulesValidatorTest {
     fun shouldCollectViolationsOfAllRules() {
         val rules = listOf(TestFirstRule())
         val validator = SwaggerRulesValidator(rulesManager(rules))
-        val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
+        val results = validator.validate(swaggerContent, RulesPolicy(emptyList()))
         assertThat(results.map(Result::description))
             .containsExactly("dummy1", "dummy2")
     }
@@ -91,7 +91,7 @@ class RulesValidatorTest {
     fun shouldSortViolationsByViolationType() {
         val rules = listOf(TestFirstRule(), TestSecondRule())
         val validator = SwaggerRulesValidator(rulesManager(rules))
-        val results = validator.validate(swaggerContent, RulesPolicy(emptyArray()))
+        val results = validator.validate(swaggerContent, RulesPolicy(emptyList()))
         assertThat(results.map(Result::description))
             .containsExactly("dummy3", "dummy1", "dummy2")
     }
@@ -100,7 +100,7 @@ class RulesValidatorTest {
     fun shouldIgnoreSpecifiedRules() {
         val rules = listOf(TestFirstRule(), TestSecondRule())
         val validator = SwaggerRulesValidator(rulesManager(rules))
-        val results = validator.validate(swaggerContent, RulesPolicy(arrayOf("TestSecondRule")))
+        val results = validator.validate(swaggerContent, RulesPolicy(listOf("TestSecondRule")))
         assertThat(results.map(Result::description))
             .containsExactly("dummy1", "dummy2")
     }
@@ -110,7 +110,7 @@ class RulesValidatorTest {
         val rules = listOf(TestBadRule())
         assertThatThrownBy {
             val validator = SwaggerRulesValidator(rulesManager(rules))
-            validator.validate(swaggerContent, RulesPolicy(arrayOf("TestCheckApiNameIsPresentRule")))
+            validator.validate(swaggerContent, RulesPolicy(listOf("TestCheckApiNameIsPresentRule")))
         }.hasMessage("Unsupported return type for a @Check method!: class java.lang.String")
     }
 


### PR DESCRIPTION
Convert `RulesPolicy` to Kotlin data class and remove dependency from `spring` annotations.

* Replace `Array` with `List` in `RulesPolicy`
* Remove `equals` and `hashCode` functions from `RulesPolicy`
* Fix unit tests
* Add `ConversionService` to support props => `List<String>` conversion by `spring`
* Fix integration test assertions to provide a proper assertion error

Fixes: #560