### PR TITLE
Add legacy hostnames validation and exceptions for specific audiences

### DIFF
--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/FunctionalNamingForHostnamesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/FunctionalNamingForHostnamesRule.kt
@@ -1,11 +1,15 @@
 package org.zalando.zally.ruleset.zalando
 
+import com.typesafe.config.Config
 import org.zalando.zally.core.toJsonPointer
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
+import org.zalando.zally.ruleset.zalando.model.ApiAudience
+import org.zalando.zally.ruleset.zalando.model.UnsupportedAudienceException
+import org.zalando.zally.ruleset.zalando.model.apiAudience
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,
@@ -13,19 +17,26 @@ import org.zalando.zally.rule.api.Violation
     severity = Severity.MUST,
     title = "Follow Naming Convention for Hostnames"
 )
-class FunctionalNamingForHostnamesRule {
-    private val audienceExtension = "x-audience"
-
+class FunctionalNamingForHostnamesRule(rulesConfig: Config) {
     private val description = "hostname has to follow the functional naming schema"
 
-    private val mustFollow = listOf("external-public", "external-partner")
-    private val shouldFollow = listOf("company-internal", "business-unit-internal")
-    private val mayFollow = listOf("component-internal")
+    private val mustFollow = listOf(ApiAudience.EXTERNAL_PUBLIC, ApiAudience.EXTERNAL_PARTNER)
+    private val shouldFollow = listOf(ApiAudience.COMPANY_INTERNAL, ApiAudience.BUSINESS_UNIT_INTERNAL)
+    private val mayFollow = listOf(ApiAudience.COMPONENT_INTERNAL)
 
     private val functionalDomain = """[a-z][a-z0-9]*"""
     private val functionalComponent = """[a-z][a-z0-9-]*"""
     private val functionHostnameURLRegEx =
         """(https://)?$functionalDomain-$functionalComponent\.zalandoapis\.com.*""".toRegex()
+
+    private val applicationId = """[a-z][a-z0-9]*"""
+    private val organizationUnit = """[a-z][a-z0-9]*"""
+    private val legacyHostnameURLRegEx =
+        """(https://)?$applicationId\.$organizationUnit\.zalan\.do.*""".toRegex()
+
+    @Suppress("UNCHECKED_CAST")
+    private val audienceExceptions = rulesConfig.getConfig("${javaClass.simpleName}.audience_exceptions").entrySet()
+        .map { (key, config) -> key to config.unwrapped() as List<String?> }.toMap()
 
     @Check(severity = Severity.MUST)
     fun mustFollowFunctionalNaming(context: Context): List<Violation> = checkHostnames(context, mustFollow)
@@ -36,25 +47,44 @@ class FunctionalNamingForHostnamesRule {
     @Check(severity = Severity.MAY)
     fun mayFollowFunctionalNaming(context: Context): List<Violation> = checkHostnames(context, mayFollow)
 
-    internal fun isUrlValid(url: String): Boolean = functionHostnameURLRegEx.matches(url)
+    internal fun isUrlValid(url: String, apiAudience: ApiAudience): Boolean =
+        functionHostnameURLRegEx.matches(url) ||
+            isValidLegacyUrl(url, apiAudience) ||
+            isUrlInExceptionList(url, apiAudience)
 
-    private fun checkHostnames(context: Context, audiencesToCheck: List<String>): List<Violation> = when {
-        context.api.info?.extensions?.get(audienceExtension) !in audiencesToCheck -> emptyList()
-        context.swagger != null -> checkHostnamesInSwaggerHost(context)
-        else -> checkHostnamesInOpenAPIServers(context)
-    }
+    private fun isValidLegacyUrl(url: String, apiAudience: ApiAudience): Boolean =
+        apiAudience == ApiAudience.COMPONENT_INTERNAL && legacyHostnameURLRegEx.matches(url)
 
-    private fun checkHostnamesInOpenAPIServers(context: Context): List<Violation> = context.api.servers
-        .orEmpty()
-        .asSequence()
-        .filterNot { isUrlValid(it.url) }
-        .map { context.violation(description, it.url) }
-        .toList()
+    private fun isUrlInExceptionList(url: String, apiAudience: ApiAudience): Boolean =
+        apiAudience == ApiAudience.EXTERNAL_PARTNER && audienceExceptions[apiAudience.code]?.contains(url) ?: false
 
-    private fun checkHostnamesInSwaggerHost(context: Context): List<Violation> = context.swagger!!.host.let { host ->
-        when {
-            host == null || isUrlValid(host) -> emptyList()
-            else -> context.violations(description, "/host".toJsonPointer())
+    private fun checkHostnames(context: Context, audiencesToCheck: List<ApiAudience>): List<Violation> {
+        val apiAudience = try {
+            context.api.info?.apiAudience()
+        } catch (e: UnsupportedAudienceException) {
+            return context.violations(e.message!!, context.api.info)
+        }
+        return when {
+            apiAudience !in audiencesToCheck -> emptyList()
+            apiAudience == null -> context.violations("API info section is not defined", context.api)
+            context.swagger != null -> checkHostnamesInSwaggerHost(context, apiAudience)
+            else -> checkHostnamesInOpenAPIServers(context, apiAudience)
         }
     }
+
+    private fun checkHostnamesInOpenAPIServers(context: Context, apiAudience: ApiAudience): List<Violation> =
+        context.api.servers
+            .orEmpty()
+            .asSequence()
+            .filterNot { isUrlValid(it.url, apiAudience) }
+            .map { context.violation(description, it.url) }
+            .toList()
+
+    private fun checkHostnamesInSwaggerHost(context: Context, apiAudience: ApiAudience): List<Violation> =
+        context.swagger!!.host.let { host ->
+            when {
+                host == null || isUrlValid(host, apiAudience) -> emptyList()
+                else -> context.violations(description, "/host".toJsonPointer())
+            }
+        }
 }

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/model/ApiAudience.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/model/ApiAudience.kt
@@ -1,0 +1,17 @@
+package org.zalando.zally.ruleset.zalando.model
+
+enum class ApiAudience(val code: String) {
+    EXTERNAL_PUBLIC("external-public"),
+    EXTERNAL_PARTNER("external-partner"),
+    COMPANY_INTERNAL("company-internal"),
+    BUSINESS_UNIT_INTERNAL("business-unit-internal"),
+    COMPONENT_INTERNAL("component-internal");
+
+    companion object {
+        fun parse(code: String): ApiAudience =
+            values().find { it.code == code }
+                ?: throw UnsupportedAudienceException(code)
+    }
+}
+
+class UnsupportedAudienceException(val code: String) : Exception("API audience $code is not supported.")

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/model/ZallyOpenApiModel.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/model/ZallyOpenApiModel.kt
@@ -1,0 +1,5 @@
+package org.zalando.zally.ruleset.zalando.model
+
+import io.swagger.v3.oas.models.info.Info
+
+fun Info.apiAudience(): ApiAudience = this.extensions?.get("x-audience").let { ApiAudience.parse(it.toString()) }

--- a/server/zally-ruleset-zalando/src/main/resources/reference.conf
+++ b/server/zally-ruleset-zalando/src/main/resources/reference.conf
@@ -214,3 +214,9 @@ DateTimePropertiesSuffixRule {
     ".*_at"
   ]
 }
+
+FunctionalNamingForHostnamesRule {
+    audience_exceptions {
+        external-partner: [api.merchants.zalando.com, api-sandbox.merchants.zalando.com]
+    }
+}


### PR DESCRIPTION
Update validation to [Rule 224](https://opensource.zalando.com/restful-api-guidelines/index.html#224).

* Exclude merchant specific hostnames from rule validation
* Add and extension to return API audience from any API
* Add `ApiAudience` enum.

Fixes #1187