### PR TITLE
Remove violation in case of successive parameters for Rule 143

### DIFF
--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/IdentifyResourcesViaPathSegments.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/IdentifyResourcesViaPathSegments.kt
@@ -18,27 +18,17 @@ import org.zalando.zally.rule.api.Violation
 )
 class IdentifyResourcesViaPathSegments {
     private val pathStartsWithParameter = "Path must start with a resource"
-    private val pathContainsSuccessiveParameters = "Path must not contain successive parameters"
     private val pathParameterContainsPrefixOrSuffix = "Path parameter must not contain prefixes and suffixes"
 
     private val pathStartingWithAParameter = """(^/\{[^/]+\}|/)""".toRegex()
+
     @Check(severity = Severity.MUST)
     fun pathStartsWithResource(context: Context): List<Violation> = context.validatePaths(
         pathFilter = { pathStartingWithAParameter.matches(it.key) },
         action = { context.violations(pathStartsWithParameter, PATHS.toJsonPointer() + it.key.toEscapedJsonPointer()) })
 
-    private val pathContainingSuccessiveParameters = """.*\}/\{.*""".toRegex()
-    @Check(severity = Severity.MUST)
-    fun pathDoesNotContainSuccessiveParameters(context: Context): List<Violation> = context.validatePaths(
-        pathFilter = { pathContainingSuccessiveParameters.matches(it.key) },
-        action = {
-            context.violations(
-                pathContainsSuccessiveParameters,
-                PATHS.toJsonPointer() + it.key.toEscapedJsonPointer()
-            )
-        })
-
     private val pathContainingPrefixedOrSuffixedParameter = """.*/([^/]+\{[^/]+\}|\{[^/]+\}[^/]+).*""".toRegex()
+
     @Check(severity = Severity.MUST)
     fun pathParameterDoesNotContainPrefixAndSuffix(context: Context): List<Violation> = context.validatePaths(
         pathFilter = { pathContainingPrefixedOrSuffixedParameter.matches(it.key) },

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/IdentifyResourcesViaPathSegmentsTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/IdentifyResourcesViaPathSegmentsTest.kt
@@ -35,27 +35,6 @@ class IdentifyResourcesViaPathSegmentsTest {
     }
 
     @Test
-    fun `should return a violation if path contains successive parameters`() {
-        val violations = rule
-            .pathDoesNotContainSuccessiveParameters(withPath("/merchants/{merchant-id}/{address-id}"))
-
-        assertThat(violations).isNotEmpty
-        assertThat(violations[0].description).containsPattern(".*must not contain successive parameters*")
-        assertThat(violations[0].pointer.toString()).isEqualTo("/paths/~1merchants~1{merchant-id}~1{address-id}")
-    }
-
-    @Test
-    fun `should not return any violations if path doesn't contain successive parameters`() {
-        assertThat(rule.pathDoesNotContainSuccessiveParameters(withPath("/customers"))).isEmpty()
-        assertThat(rule.pathDoesNotContainSuccessiveParameters(withPath("/customers/{customer-id}"))).isEmpty()
-        assertThat(
-            rule.pathDoesNotContainSuccessiveParameters(
-                withPath("/customers/{customer-id}/addresses/primary")
-            )
-        ).isEmpty()
-    }
-
-    @Test
     fun `should return a violation if path parameter contains prefix`() {
         val violations = rule.pathParameterDoesNotContainPrefixAndSuffix(
             withPath("/orders/de-{order-id}")


### PR DESCRIPTION
[Rule 241](https://opensource.zalando.com/restful-api-guidelines/#241) relaxes requirements of [Rule 143](https://opensource.zalando.com/restful-api-guidelines/#143) and allows to define compound keys successive parameters.

Fixes #1182 