### PR TITLE
fix: authorization token propagation (#1306)

### DIFF
--- a/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/ContextFactoryConfiguration.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/ContextFactoryConfiguration.kt
@@ -14,6 +14,6 @@ class ContextFactoryConfiguration {
 
     @Bean
     fun contextFactory(): DefaultContextFactory {
-        return DefaultContextFactory()
+        return DefaultContextFactory(propagateAuthorizationUrls)
     }
 }


### PR DESCRIPTION
#1306

Fix the forwarding of the authorization propagation URLs patterns during instantiation of the `DefaultContextFactory`.