### PR TITLE
Remove "github-integration" module from build script

### DIFF
--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -13,15 +13,11 @@ popd > /dev/null
 
 SERVER_DIR=${SCRIPT_DIR}/server
 WEB_UI_DIR=${SCRIPT_DIR}/web-ui
-GITHUB_INTEGRATION_DIR=${SCRIPT_DIR}/github_integration
 
 # Build web ui
 cd ${WEB_UI_DIR} && yarn && yarn build
 
 if [[ "$@" == "--bark" ]]; then
-
-    #Build Bark
-    cd ${GITHUB_INTEGRATION_DIR} && ./gradlew build -x test
 
     # Docker-compose
     cd ${SCRIPT_DIR} && docker-compose -f docker-compose.yaml -f docker-compose-bark.yaml up --build


### PR DESCRIPTION
Remove deleted `github-integration` module from a build script.