### PR TITLE
feat: change severity of proprietary header rule (#1367)

### DIFF
--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/ProprietaryHeadersRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/ProprietaryHeadersRule.kt
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.models.parameters.Parameter
 @Rule(
     ruleSet = ZalandoRuleSet::class,
     id = "183",
-    severity = Severity.MUST,
+    severity = Severity.SHOULD,
     title = "Use Only the Specified Proprietary Zalando Headers"
 )
 class ProprietaryHeadersRule(rulesConfig: Config) {


### PR DESCRIPTION
It seems we have overlooked a two years old guideline change on the severity of proprietary header usage that was changed from MUST to SHOULD (see https://opensource.zalando.com/restful-api-guidelines/#183).