### PR TITLE
feat: upgrade to kotlin 1.8 (#1435)

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -6,6 +6,7 @@ pipeline:
     vm_config:
       type: linux
       image: cdp-runtime/jdk17
+      size: large
     commands:
       - desc: Build server
         cmd: |

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -7,7 +7,7 @@ java {
 }
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.8.0"
     val klintVersion = "11.0.0"
 
     // The buildscript is also kotlin, so we apply at the root level
@@ -20,12 +20,10 @@ plugins {
     `maven-publish`
     signing
     eclipse
-    id("com.github.ben-manes.versions") version "0.44.0"
-    id("org.jetbrains.dokka") version "1.7.20" apply false
 
-    // We apply this so that ktlint can format the top level buildscript
-    id("org.jlleitschuh.gradle.ktlint") version klintVersion
-    id("org.jlleitschuh.gradle.ktlint-idea") version klintVersion
+    id("org.jetbrains.dokka") version "1.7.20" apply false
+    id("com.github.ben-manes.versions") version "0.44.0"
+    id("com.diffplug.spotless") version "6.12.1"
 }
 
 allprojects {
@@ -35,13 +33,12 @@ allprojects {
 }
 
 subprojects {
-
     group = "org.zalando"
 
     apply(plugin = "kotlin")
     apply(plugin = "kotlin-kapt")
-    apply(plugin = "org.jlleitschuh.gradle.ktlint")
     apply(plugin = "com.github.ben-manes.versions")
+    apply(plugin = "com.diffplug.spotless")
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "maven-publish")
     apply(plugin = "jacoco")
@@ -156,6 +153,7 @@ subprojects {
 
     dependencies {
         implementation("org.jetbrains.kotlin:kotlin-stdlib")
+        implementation("org.jetbrains.kotlin:kotlin-reflect")
 
         // We define this here so all subprojects use the same version of jackson
         implementation("com.fasterxml.jackson.core:jackson-databind:2.14.1")
@@ -173,6 +171,17 @@ subprojects {
     jacoco {
         toolVersion = "0.8.8"
     }
+
+    // spotless {
+    //     kotlin {
+    //         target("**/*.kt")
+    //         ktlint("0.47.1")
+    //     }
+    //     kotlinGradle {
+    //         target("**/*.gradle.kts", "*.gradle.kts")
+    //         ktlint("0.47.1")
+    //     }
+    // }
 
     tasks.test {
         useJUnitPlatform()

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/ContentParseResultAssert.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/ContentParseResultAssert.kt
@@ -31,7 +31,7 @@ class ContentParseResultAssert<T : Any>(actual: ContentParseResult<T>?) :
                     is ContentParseResult.NotApplicable -> "Expected result to be '$type'. Was 'NotApplicable' instead."
                     is ContentParseResult.ParsedWithErrors -> {
                         val sep = "\n  - "
-                        val violations = actual.violations.joinToString(sep, sep, "\n")
+                        val violations = (actual as ContentParseResult.ParsedWithErrors).violations.joinToString(sep, sep, "\n")
                         "Expected result to be '$type'. Was 'ParsedWithErrors' instead with those violations: $violations"
                     }
                     is ContentParseResult.ParsedSuccessfully -> "Expected result to be '$type'. Was 'ParsedSuccessfully' instead."

--- a/server/zally-server/build.gradle.kts
+++ b/server/zally-server/build.gradle.kts
@@ -2,7 +2,7 @@
 version = ""
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.8.0"
 
     kotlin("plugin.jpa") version kotlinVersion
     kotlin("plugin.noarg") version kotlinVersion
@@ -26,7 +26,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa") {
         exclude("org.hibernate", "hibernate-entitymanager")
     }
-    implementation("org.flywaydb:flyway-core:9.10.2")
+    implementation("org.flywaydb:flyway-core:9.11.0")
     implementation("org.hsqldb:hsqldb:2.7.1")
     implementation("org.postgresql:postgresql:42.5.1")
     implementation("org.hibernate:hibernate-core")

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/JacksonObjectMapperConfiguration.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/JacksonObjectMapperConfiguration.kt
@@ -38,7 +38,7 @@ class JacksonObjectMapperConfiguration {
                 Jdk8Module(),
                 JavaTimeModule(),
                 ProblemModule(),
-                KotlinModule()
+                KotlinModule.Builder().build()
             )
         return mapper
     }


### PR DESCRIPTION
Updates Kotlin version and prepares the switching of the linter plugin to apply the newest ktlint standard. Also fixes the broken build that needs a bigger host for building the docker container.