### PR TITLE
feat: activate and apply new linter (#1437)

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -14,7 +14,8 @@ pipeline:
           if [ -n "${CDP_PULL_REQUEST_NUMBER}" ]; then
             echo "We're in a pull request, aborting."; exit 0;
           fi;
-          IMAGE="${DOCKER_IMAGE_PREFIX}/zally:${CDP_BUILD_VERSION}"
+          PREFIX: "pierone.stups.zalan.do/builder-knowledge"
+          IMAGE="${PREFIX}/zally:${CDP_PULL_REQUEST_NUMBER}"
           docker build -t "${IMAGE}" . && docker push "${IMAGE}"
     cache:
       paths: [ ~/.gradle/caches, ~/.gradle/wrapper ]
@@ -32,7 +33,8 @@ pipeline:
           if [ -n "${CDP_PULL_REQUEST_NUMBER}" ]; then
             echo "We're in a pull request, aborting."; exit 0;
           fi;
-          IMAGE="${DOCKER_IMAGE_PREFIX}/zally-web-ui-dummy:${CDP_BUILD_VERSION}"
+          PREFIX: "pierone.stups.zalan.do/builder-knowledge"
+          IMAGE="${PREFIX}/zally-web-ui-dummy:${CDP_BUILD_VERSION}"
           docker build -t "${IMAGE}" . && docker push "${IMAGE}"
     cache:
       paths: [ ~/.npm ]

--- a/server/README.md
+++ b/server/README.md
@@ -23,6 +23,12 @@ cd zally/server
 ./gradlew clean build
 ```
 
+1. Fix linter violations
+
+```bash
+./gradlew spotlessApply
+```
+
 1. Run Zally server using:
 
 ```bash

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -172,16 +172,16 @@ subprojects {
         toolVersion = "0.8.8"
     }
 
-    // spotless {
-    //     kotlin {
-    //         target("**/*.kt")
-    //         ktlint("0.47.1")
-    //     }
-    //     kotlinGradle {
-    //         target("**/*.gradle.kts", "*.gradle.kts")
-    //         ktlint("0.47.1")
-    //     }
-    // }
+    spotless {
+        kotlin {
+            target("**/*.kt")
+            ktlint("0.47.1")
+        }
+        kotlinGradle {
+            target("**/*.gradle.kts", "*.gradle.kts")
+            ktlint("0.47.1")
+        }
+    }
 
     tasks.test {
         useJUnitPlatform()

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/CaseChecker.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/CaseChecker.kt
@@ -1,15 +1,15 @@
 package org.zalando.zally.core
 
 import com.typesafe.config.Config
-import org.zalando.zally.rule.api.Context
-import org.zalando.zally.rule.api.Violation
+import io.github.config4k.extract
+import io.swagger.v3.oas.models.media.Schema
 import org.zalando.zally.core.util.PatternUtil
 import org.zalando.zally.core.util.getAllHeaders
 import org.zalando.zally.core.util.getAllParameters
 import org.zalando.zally.core.util.getAllProperties
 import org.zalando.zally.core.util.getAllSchemas
-import io.github.config4k.extract
-import io.swagger.v3.oas.models.media.Schema
+import org.zalando.zally.rule.api.Context
+import org.zalando.zally.rule.api.Violation
 
 /**
  * Utility class for checking cases of strings against configured requirements.

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/ContentParseResult.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/ContentParseResult.kt
@@ -30,8 +30,11 @@ sealed class ContentParseResult<out RootT : Any> {
         is ParsedWithErrors -> ParsedWithErrors(violations)
         is ParsedSuccessfully -> {
             val resultT = result as? T
-            if (resultT == null) throw IllegalStateException("Cannot change the type of a ParsedSuccessfully")
-            else ParsedSuccessfully(resultT)
+            if (resultT == null) {
+                throw IllegalStateException("Cannot change the type of a ParsedSuccessfully")
+            } else {
+                ParsedSuccessfully(resultT)
+            }
         }
     }
 }

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/DefaultContext.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/DefaultContext.kt
@@ -1,15 +1,15 @@
 package org.zalando.zally.core
 
 import com.fasterxml.jackson.core.JsonPointer
-import org.zalando.zally.core.ast.ReverseAst
-import org.zalando.zally.rule.api.Context
-import org.zalando.zally.rule.api.Violation
 import io.swagger.models.Swagger
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.PathItem.HttpMethod
 import io.swagger.v3.oas.models.responses.ApiResponse
+import org.zalando.zally.core.ast.ReverseAst
+import org.zalando.zally.rule.api.Context
+import org.zalando.zally.rule.api.Violation
 
 class DefaultContext(
     override val source: String,

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/JsonPointerLocator.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/JsonPointerLocator.kt
@@ -36,7 +36,9 @@ class JsonPointerLocator(contents: String) {
             val keyNode = tuple.keyNode
             if (keyNode is ScalarNode && pointer.matchesProperty(keyNode.value)) {
                 locate(pointer.tail(), tuple.valueNode, keyNode)
-            } else null
+            } else {
+                null
+            }
         }
         .firstOrNull()
 
@@ -44,7 +46,9 @@ class JsonPointerLocator(contents: String) {
         .mapIndexedNotNull { index, any ->
             if (any is Node && pointer.matchesElement(index)) {
                 locate(pointer.tail(), any)
-            } else null
+            } else {
+                null
+            }
         }
         .firstOrNull()
 }

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/JsonRulesValidator.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/JsonRulesValidator.kt
@@ -2,8 +2,8 @@ package org.zalando.zally.core
 
 import com.fasterxml.jackson.core.JsonPointer
 import com.fasterxml.jackson.databind.JsonNode
-import org.zalando.zally.core.ast.ReverseAst
 import io.swagger.util.Json
+import org.zalando.zally.core.ast.ReverseAst
 
 class JsonRulesValidator(rules: RulesManager) : RulesValidator<JsonNode>(rules) {
     private var ast: ReverseAst? = null

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/RulesValidator.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/RulesValidator.kt
@@ -1,12 +1,12 @@
 package org.zalando.zally.core
 
 import com.fasterxml.jackson.core.JsonPointer
+import org.slf4j.LoggerFactory
 import org.zalando.zally.core.ContentParseResult.NotApplicable
 import org.zalando.zally.core.ContentParseResult.ParsedSuccessfully
 import org.zalando.zally.core.ContentParseResult.ParsedWithErrors
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationTargetException
 import java.net.URI
 

--- a/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/OpenApiUtil.kt
+++ b/server/zally-core/src/main/kotlin/org/zalando/zally/core/util/OpenApiUtil.kt
@@ -13,7 +13,6 @@ data class HeaderElement(
 )
 
 fun OpenAPI.getAllHeaders(): Set<HeaderElement> {
-
     fun Collection<Parameter>?.extractHeaders() = orEmpty()
         .filter { it.`in` == "header" }
         .map { HeaderElement(it.name, it) }
@@ -164,7 +163,9 @@ fun Schema<Any>.isExtensibleEnum(): Boolean =
 fun Schema<Any>.extensibleEnum(): List<Any?> =
     if (this.isExtensibleEnum()) {
         (this.extensions["x-extensible-enum"] as List<Any?>)
-    } else emptyList<Any?>()
+    } else {
+        emptyList<Any?>()
+    }
 
 fun Parameter.isInPath() = this.`in` == "path"
 

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/ContentParseResultAssert.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/ContentParseResultAssert.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.core
 
-import org.zalando.zally.rule.api.Context
-import org.zalando.zally.rule.api.Violation
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions
+import org.zalando.zally.rule.api.Context
+import org.zalando.zally.rule.api.Violation
 
 class ContentParseResultAssert<T : Any>(actual: ContentParseResult<T>?) :
     AbstractAssert<ContentParseResultAssert<T>, ContentParseResult<T>?>(actual, ContentParseResultAssert::class.java) {

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/DefaultContextFactoryTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.core
 
-import org.zalando.zally.core.ContentParseResultAssert.Companion.assertThat
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.zalando.zally.core.ContentParseResultAssert.Companion.assertThat
 
 class DefaultContextFactoryTest {
 

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/JsonSchemaValidatorTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/JsonSchemaValidatorTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.core
 
 import com.google.common.io.Resources
-import org.zalando.zally.test.ZallyAssertions.assertThat
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.zalando.zally.test.ZallyAssertions.assertThat
 
 class JsonSchemaValidatorTest {
 

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/ObjectTreeReaderTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/ObjectTreeReaderTest.kt
@@ -84,7 +84,6 @@ class ObjectTreeReaderTest {
     /** Tests that advanced YAML is supported */
     @Test
     fun readSupportsYamlAnchorsAndReferences() {
-
         val contents = """
             Idable:
               type: object

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/RulesPolicyTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/RulesPolicyTest.kt
@@ -1,13 +1,13 @@
 package org.zalando.zally.core
 
-import org.zalando.zally.rule.api.Check
-import org.zalando.zally.rule.api.Rule
-import org.zalando.zally.rule.api.Severity
-import org.zalando.zally.rule.api.Violation
 import io.swagger.models.Swagger
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.zalando.zally.rule.api.Check
+import org.zalando.zally.rule.api.Rule
+import org.zalando.zally.rule.api.Severity
+import org.zalando.zally.rule.api.Violation
 
 class RulesPolicyTest {
 

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/SwaggerRulesValidatorTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/SwaggerRulesValidatorTest.kt
@@ -3,15 +3,15 @@ package org.zalando.zally.core
 import com.fasterxml.jackson.core.JsonPointer
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.config.ConfigFactory
-import org.zalando.zally.rule.api.Check
-import org.zalando.zally.rule.api.Rule
-import org.zalando.zally.rule.api.Severity
-import org.zalando.zally.rule.api.Violation
 import io.swagger.models.Swagger
 import org.apache.commons.io.IOUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.zalando.zally.rule.api.Check
+import org.zalando.zally.rule.api.Rule
+import org.zalando.zally.rule.api.Severity
+import org.zalando.zally.rule.api.Violation
 
 @Suppress("UndocumentedPublicClass", "StringLiteralDuplication")
 class SwaggerRulesValidatorTest {

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/ast/ReverseAstBuilderTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/ast/ReverseAstBuilderTest.kt
@@ -1,6 +1,5 @@
 package org.zalando.zally.core.ast
 
-import org.zalando.zally.core.ast.ReverseAstBuilder.Companion.traversalMethods
 import io.swagger.models.Swagger
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.PathItem
@@ -8,13 +7,13 @@ import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.parameters.QueryParameter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.ast.ReverseAstBuilder.Companion.traversalMethods
 
 @Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction", "StringLiteralDuplication")
 class ReverseAstBuilderTest {
 
     @Test
     fun `traversalMethods with Enum skips getClass and getDeclaringClass`() {
-
         val methods = traversalMethods(PathItem.HttpMethod::class.java).map { it.name }
 
         assertThat(methods).isEmpty()
@@ -22,7 +21,6 @@ class ReverseAstBuilderTest {
 
     @Test
     fun `traversalMethods with Info returns declared getters only`() {
-
         val methods = traversalMethods(Info::class.java).map { it.name }
 
         assertThat(methods).containsExactly(
@@ -39,7 +37,6 @@ class ReverseAstBuilderTest {
 
     @Test
     fun `traversalMethods with QueryParameter returns inherited getters too`() {
-
         val methods = traversalMethods(QueryParameter::class.java).map { it.name }
 
         assertThat(methods).containsExactly(
@@ -63,7 +60,6 @@ class ReverseAstBuilderTest {
 
     @Test
     fun `traversalMethods with Swagger returns getPaths last`() {
-
         val methods = traversalMethods(Swagger::class.java).map { it.name }
 
         assertThat(methods).containsExactly(
@@ -88,7 +84,6 @@ class ReverseAstBuilderTest {
 
     @Test
     fun `traversalMethods with OpenAPI returns leaves returns getPaths last`() {
-
         val methods = traversalMethods(OpenAPI::class.java).map { it.name }
 
         assertThat(methods).containsExactly(

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/util/OpenApiUtilTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/util/OpenApiUtilTest.kt
@@ -1,6 +1,5 @@
 package org.zalando.zally.core.util
 
-import org.zalando.zally.core.DefaultContextFactory
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
@@ -17,6 +16,7 @@ import io.swagger.v3.oas.models.responses.ApiResponses
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class OpenApiUtilTest {
 

--- a/server/zally-core/src/test/kotlin/org/zalando/zally/core/util/PatternUtilTest.kt
+++ b/server/zally-core/src/test/kotlin/org/zalando/zally/core/util/PatternUtilTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.core.util
 
-import org.zalando.zally.core.util.PatternUtil.isPathVariable
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.util.PatternUtil.isPathVariable
 
 /**
  * Unit tests for patterns utility

--- a/server/zally-rule-api/src/test/kotlin/org/zalando/zally/rule/api/SeverityTest.kt
+++ b/server/zally-rule-api/src/test/kotlin/org/zalando/zally/rule/api/SeverityTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.rule.api
 
-import org.zalando.zally.rule.api.Severity.HINT
-import org.zalando.zally.rule.api.Severity.MUST
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.zalando.zally.rule.api.Severity.HINT
+import org.zalando.zally.rule.api.Severity.MUST
 
 class SeverityTest {
 

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/ApiMetaInformationRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/ApiMetaInformationRule.kt
@@ -21,13 +21,17 @@ class ApiMetaInformationRule {
     fun checkInfoTitle(context: Context): Violation? =
         if (context.api.info?.title.isNullOrBlank()) {
             context.violation("Title has to be provided", "/info/title".toJsonPointer())
-        } else null
+        } else {
+            null
+        }
 
     @Check(severity = Severity.MUST)
     fun checkInfoDescription(context: Context): Violation? =
         if (context.api.info?.description.isNullOrBlank()) {
             context.violation("Description has to be provided", "/info/description".toJsonPointer())
-        } else null
+        } else {
+            null
+        }
 
     @Check(severity = Severity.MUST)
     fun checkInfoVersion(context: Context): Violation? {
@@ -45,17 +49,23 @@ class ApiMetaInformationRule {
     fun checkContactName(context: Context): Violation? =
         if (context.api.info?.contact?.name.isNullOrBlank()) {
             context.violation("Contact name has to be provided", "/info/contact/name".toJsonPointer())
-        } else null
+        } else {
+            null
+        }
 
     @Check(severity = Severity.MUST)
     fun checkContactUrl(context: Context): Violation? =
         if (context.api.info?.contact?.url.isNullOrBlank()) {
             context.violation("Contact URL has to be provided", "/info/contact/url".toJsonPointer())
-        } else null
+        } else {
+            null
+        }
 
     @Check(severity = Severity.MUST)
     fun checkContactEmail(context: Context): Violation? =
         if (context.api.info?.contact?.email.isNullOrBlank()) {
             context.violation("Contact e-mail has to be provided", "/info/contact/email".toJsonPointer())
-        } else null
+        } else {
+            null
+        }
 }

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/CommonFieldTypesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/CommonFieldTypesRule.kt
@@ -48,7 +48,6 @@ class CommonFieldTypesRule(rulesConfig: Config) {
         objectSchema: Schema<Any>,
         check: (parentObject: Schema<Any>, name: String, schema: Schema<Any>) -> Collection<Violation>
     ): Collection<Violation> {
-
         fun traverse(oSchema: Schema<Any>): List<Violation?> = oSchema.properties.orEmpty().flatMap { (name, schema) ->
             if (schema.properties.isNullOrEmpty()) {
                 check(oSchema, name, schema)
@@ -62,10 +61,12 @@ class CommonFieldTypesRule(rulesConfig: Config) {
 
     internal fun checkField(name: String, property: Schema<Any>): String? =
         commonFields[name]?.let { (type, format) ->
-            if (property.type != type)
+            if (property.type != type) {
                 "field '$name' has type '${property.type}' (expected type '$type')"
-            else if (property.format != format && format != null)
+            } else if (property.format != format && format != null) {
                 "field '$name' has type '${property.type}' with format '${property.format}' (expected format '$format')"
-            else null
+            } else {
+                null
+            }
         }
 }

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRule.kt
@@ -1,13 +1,13 @@
 package org.zalando.zally.ruleset.zalando
 
 import com.typesafe.config.Config
+import io.swagger.v3.oas.models.media.Schema
+import org.zalando.zally.core.util.getAllProperties
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import org.zalando.zally.core.util.getAllProperties
-import io.swagger.v3.oas.models.media.Schema
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/FormatForNumbersRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/FormatForNumbersRule.kt
@@ -18,6 +18,7 @@ class FormatForNumbersRule(rulesConfig: Config) {
     private val description = """Numeric properties must have valid format specified"""
 
     private val numberTypes = listOf("integer", "number")
+
     @Suppress("UNCHECKED_CAST")
     private val type2format = rulesConfig.getConfig("${javaClass.simpleName}.formats").entrySet()
         .map { (key, config) -> key to config.unwrapped() as List<String> }.toMap()

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/JsonProblemAsDefaultResponseRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/JsonProblemAsDefaultResponseRule.kt
@@ -1,13 +1,13 @@
 package org.zalando.zally.ruleset.zalando
 
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.responses.ApiResponse
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import io.swagger.v3.oas.models.Operation
-import io.swagger.v3.oas.models.media.Schema
-import io.swagger.v3.oas.models.responses.ApiResponse
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/LimitNumberOfResourcesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/LimitNumberOfResourcesRule.kt
@@ -1,12 +1,12 @@
 package org.zalando.zally.ruleset.zalando
 
 import com.typesafe.config.Config
+import org.zalando.zally.core.util.PatternUtil.isPathVariable
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import org.zalando.zally.core.util.PatternUtil.isPathVariable
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,
@@ -32,7 +32,9 @@ class LimitNumberOfResourcesRule(rulesConfig: Config) {
                     "greater than recommended limit of $resourceTypesLimit",
                 context.api.paths
             )
-        } else null
+        } else {
+            null
+        }
     }
 
     internal fun resourceTypes(paths: Collection<String>): List<String> {

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/MediaTypesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/MediaTypesRule.kt
@@ -1,16 +1,16 @@
 package org.zalando.zally.ruleset.zalando
 
 import com.typesafe.config.Config
-import org.zalando.zally.rule.api.Check
-import org.zalando.zally.rule.api.Context
-import org.zalando.zally.rule.api.Rule
-import org.zalando.zally.rule.api.Severity
-import org.zalando.zally.rule.api.Violation
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.Content
 import io.swagger.v3.oas.models.media.MediaType
 import io.swagger.v3.oas.models.parameters.RequestBody
 import io.swagger.v3.oas.models.responses.ApiResponse
+import org.zalando.zally.rule.api.Check
+import org.zalando.zally.rule.api.Context
+import org.zalando.zally.rule.api.Rule
+import org.zalando.zally.rule.api.Severity
+import org.zalando.zally.rule.api.Violation
 
 /**
  * @see "https://opensource.zalando.com/restful-api-guidelines/#172"

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/NoVersionInUriRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/NoVersionInUriRule.kt
@@ -1,13 +1,13 @@
 package org.zalando.zally.ruleset.zalando
 
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.PathItem
+import io.swagger.v3.oas.models.servers.Server
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import io.swagger.v3.oas.models.OpenAPI
-import io.swagger.v3.oas.models.PathItem
-import io.swagger.v3.oas.models.servers.Server
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/ProprietaryHeadersRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/ProprietaryHeadersRule.kt
@@ -1,13 +1,13 @@
 package org.zalando.zally.ruleset.zalando
 
 import com.typesafe.config.Config
+import io.swagger.v3.oas.models.headers.Header
+import io.swagger.v3.oas.models.parameters.Parameter
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import io.swagger.v3.oas.models.headers.Header
-import io.swagger.v3.oas.models.parameters.Parameter
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/QueryParameterCollectionFormatRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/QueryParameterCollectionFormatRule.kt
@@ -1,12 +1,12 @@
 package org.zalando.zally.ruleset.zalando
 
+import io.swagger.v3.oas.models.parameters.Parameter
 import org.zalando.zally.core.util.getAllParameters
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import io.swagger.v3.oas.models.parameters.Parameter
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,
@@ -20,10 +20,12 @@ class QueryParameterCollectionFormatRule {
 
     @Check(severity = Severity.SHOULD)
     fun checkParametersCollectionFormat(context: Context): List<Violation> =
-        if (context.isOpenAPI3())
+        if (context.isOpenAPI3()) {
             context.api.getAllParameters()
                 .filter { "query" == it.`in` && "array" == it.schema?.type }
                 .filter { it.style == null || allowedStyle != it.style }
                 .map { context.violation(description, it) }
-        else emptyList()
+        } else {
+            emptyList()
+        }
 }

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/SecureAllEndpointsRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/SecureAllEndpointsRule.kt
@@ -24,10 +24,14 @@ class SecureAllEndpointsRule {
             it.isOAuth2() || it.isBearer()
         }.orEmpty()
 
-        return if (valid.isEmpty()) context.violation(
-            "API must be secured by OAuth2 or Bearer Authentication",
-            "/components/securitySchemes".toJsonPointer()
-        ) else null
+        return if (valid.isEmpty()) {
+            context.violation(
+                "API must be secured by OAuth2 or Bearer Authentication",
+                "/components/securitySchemes".toJsonPointer()
+            )
+        } else {
+            null
+        }
     }
 
     @Check(severity = Severity.MUST)
@@ -67,7 +71,8 @@ class SecureAllEndpointsRule {
             .filter { (group, _) -> specifiedSchemes.get(group)?.isOAuth2() ?: false }
             .filterNot { it in specifiedScopes }.map { (group, scope) ->
                 context.violation(
-                    "The scope '$group/$scope' is not specified in security definition", scope
+                    "The scope '$group/$scope' is not specified in security definition",
+                    scope
                 )
             }
     }

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/SecureAllEndpointsWithScopesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/SecureAllEndpointsWithScopesRule.kt
@@ -57,7 +57,6 @@ class SecureAllEndpointsWithScopesRule(rulesConfig: Config) {
         // val definedScopes = definedScopes(context.api)
         return context.validateOperations(pathFilter = this::pathFilter) { (_, op) ->
             op?.let {
-
                 val definedOpSecurityRequirements = definedSecurityRequirements(op, context.api)
 
                 if (definedOpSecurityRequirements.isEmpty()) {
@@ -99,7 +98,8 @@ class SecureAllEndpointsWithScopesRule(rulesConfig: Config) {
     ): Violation? {
         if (requestedScopes.isEmpty()) {
             return context.violation(
-                "Endpoint is not secured by OAuth2 scope(s)", op.security ?: op
+                "Endpoint is not secured by OAuth2 scope(s)",
+                op.security ?: op
             )
         }
         val definedScopes = definedScheme.allScopes()
@@ -110,7 +110,9 @@ class SecureAllEndpointsWithScopesRule(rulesConfig: Config) {
                 "Endpoint is secured by undefined OAuth2 scope(s): $schemeName:${undefined.joinToString()}",
                 op.security ?: op
             )
-        } else null
+        } else {
+            null
+        }
     }
 
     private fun pathFilter(entry: Map.Entry<String, PathItem?>): Boolean =

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnums.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UpperCaseEnums.kt
@@ -43,7 +43,9 @@ class UpperCaseEnums {
     private fun validateEnum(scheme: Schema<Any>, context: Context): List<Violation> {
         val enumValues = if (scheme.isExtensibleEnum()) {
             scheme.extensibleEnum()
-        } else scheme.enum
+        } else {
+            scheme.enum
+        }
 
         return enumValues.filterNotNull().filterNot { it is String }.map {
             context.violation(

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/Use429HeaderForRateLimitRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/Use429HeaderForRateLimitRule.kt
@@ -1,5 +1,6 @@
 package org.zalando.zally.ruleset.zalando
 
+import io.swagger.v3.oas.models.responses.ApiResponse
 import org.zalando.zally.core.plus
 import org.zalando.zally.core.toEscapedJsonPointer
 import org.zalando.zally.rule.api.Check
@@ -7,7 +8,6 @@ import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import io.swagger.v3.oas.models.responses.ApiResponse
 
 @Rule(
     ruleSet = ZalandoRuleSet::class,

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesRule.kt
@@ -2,12 +2,12 @@ package org.zalando.zally.ruleset.zalando
 
 import com.typesafe.config.Config
 import io.swagger.v3.oas.models.PathItem
+import org.zalando.zally.core.util.HttpStatus
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import org.zalando.zally.core.util.HttpStatus
 
 /**
  * Validate that HTTP methods and statuses align as expected

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ApiAudienceRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ApiAudienceRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.test.ZallyAssertions.assertThat
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.rule.api.Context
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
+import org.zalando.zally.rule.api.Context
+import org.zalando.zally.test.ZallyAssertions.assertThat
 
 class ApiAudienceRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ApiIdentifierRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ApiIdentifierRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
+import org.junit.jupiter.api.Test
 import org.zalando.zally.core.DefaultContextFactory
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.test.ZallyAssertions.assertThat
-import org.junit.jupiter.api.Test
 
 class ApiIdentifierRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ApiMetaInformationRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ApiMetaInformationRuleTest.kt
@@ -1,8 +1,8 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class ApiMetaInformationRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/AvoidLinkHeadersRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/AvoidLinkHeadersRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.test.ZallyAssertions.assertThat
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
+import org.zalando.zally.test.ZallyAssertions.assertThat
 
 class AvoidLinkHeadersRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/AvoidTrailingSlashesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/AvoidTrailingSlashesRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.test.ZallyAssertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.test.ZallyAssertions.assertThat
 
 @Suppress("StringLiteralDuplication", "UndocumentedPublicClass", "UnsafeCallOnNullableType")
 class AvoidTrailingSlashesRuleTest {

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/CommonFieldTypesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/CommonFieldTypesRuleTest.kt
@@ -1,7 +1,5 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import io.swagger.v3.parser.util.SchemaTypeUtil.DATE_TIME_FORMAT
 import io.swagger.v3.parser.util.SchemaTypeUtil.INTEGER_TYPE
 import io.swagger.v3.parser.util.SchemaTypeUtil.STRING_TYPE
@@ -10,6 +8,8 @@ import io.swagger.v3.parser.util.SchemaTypeUtil.createSchema
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
 
 class CommonFieldTypesRuleTest {
     private val rule = CommonFieldTypesRule(rulesConfig)

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRuleTest.kt
@@ -3,11 +3,11 @@
 package org.zalando.zally.ruleset.zalando
 
 import com.typesafe.config.ConfigValueFactory
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
 
 class DateTimePropertiesSuffixRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ExtensibleEnumRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ExtensibleEnumRuleTest.kt
@@ -1,8 +1,8 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class ExtensibleEnumRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/FunctionalNamingForHostnamesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/FunctionalNamingForHostnamesRuleTest.kt
@@ -1,11 +1,11 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.rule.api.Context
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
+import org.zalando.zally.rule.api.Context
 import org.zalando.zally.ruleset.zalando.model.ApiAudience
 
 class FunctionalNamingForHostnamesRuleTest {
@@ -196,7 +196,6 @@ class FunctionalNamingForHostnamesRuleTest {
     }
 
     private fun getSwaggerContextWith(audience: String?, url: String?): Context {
-
         val content = listOfNotNull(
             """
             swagger: '2.0'

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/IdentifyResourcesViaPathSegmentsTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/IdentifyResourcesViaPathSegmentsTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.rule.api.Context
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.rule.api.Context
 
 class IdentifyResourcesViaPathSegmentsTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/JsonProblemAsDefaultResponseRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/JsonProblemAsDefaultResponseRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class JsonProblemAsDefaultResponseRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/KebabCaseInPathSegmentsRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/KebabCaseInPathSegmentsRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
 
 class KebabCaseInPathSegmentsRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/LimitNumberOfSubResourcesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/LimitNumberOfSubResourcesRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
 
 class LimitNumberOfSubResourcesRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/MediaTypesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/MediaTypesRuleTest.kt
@@ -1,15 +1,15 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContext
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.toJsonPointer
-import org.zalando.zally.rule.api.Violation
 import io.swagger.parser.util.ClasspathHelper.loadFileFromClasspath
 import io.swagger.v3.oas.models.OpenAPI
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContext
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
+import org.zalando.zally.core.toJsonPointer
+import org.zalando.zally.rule.api.Violation
 
 class MediaTypesRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/NestedPathsMayBeRootPathsRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/NestedPathsMayBeRootPathsRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class NestedPathsMayBeRootPathsRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/NoVersionInUriRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/NoVersionInUriRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class NoVersionInUriRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/PascalCaseHttpHeadersRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/PascalCaseHttpHeadersRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
 
 class PascalCaseHttpHeadersRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/PluralizeNamesForArraysRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/PluralizeNamesForArraysRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.test.ZallyAssertions
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.test.ZallyAssertions
 
 class PluralizeNamesForArraysRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/PluralizeResourceNamesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/PluralizeResourceNamesRuleTest.kt
@@ -1,13 +1,13 @@
 package org.zalando.zally.ruleset.zalando
 
+import io.swagger.parser.util.ClasspathHelper.loadFileFromClasspath
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.zalando.zally.core.ContentParseResult.ParsedSuccessfully
 import org.zalando.zally.core.DefaultContextFactory
 import org.zalando.zally.core.rulesConfig
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.test.ZallyAssertions.assertThat
-import io.swagger.parser.util.ClasspathHelper.loadFileFromClasspath
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
 
 class PluralizeResourceNamesRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ProprietaryHeadersRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/ProprietaryHeadersRuleTest.kt
@@ -1,11 +1,11 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.rule.api.Context
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
+import org.zalando.zally.rule.api.Context
 
 class ProprietaryHeadersRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/QueryParameterCollectionFormatRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/QueryParameterCollectionFormatRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class QueryParameterCollectionFormatRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SecureAllEndpointsRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SecureAllEndpointsRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.test.ZallyAssertions
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.test.ZallyAssertions
 
 class SecureAllEndpointsRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SecureAllEndpointsWithScopesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SecureAllEndpointsWithScopesRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
 import org.zalando.zally.core.DefaultContextFactory
 import org.zalando.zally.ruleset.zalando.util.getConfigFromContent
 import org.zalando.zally.test.ZallyAssertions
-import org.intellij.lang.annotations.Language
-import org.junit.jupiter.api.Test
 import org.zalando.zally.test.ZallyAssertions.assertThat
 
 /**

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SnakeCaseForQueryParamsRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SnakeCaseForQueryParamsRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
 
 class SnakeCaseForQueryParamsRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SnakeCaseInPropNameRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SnakeCaseInPropNameRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
 
 class SnakeCaseInPropNameRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SuccessResponseAsJsonObjectRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/SuccessResponseAsJsonObjectRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class SuccessResponseAsJsonObjectRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/Use429HeaderForRateLimitRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/Use429HeaderForRateLimitRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class Use429HeaderForRateLimitRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseOpenApiRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseOpenApiRuleTest.kt
@@ -1,14 +1,14 @@
 package org.zalando.zally.ruleset.zalando
 
 import com.typesafe.config.ConfigFactory
-import org.zalando.zally.core.DefaultContext
-import org.zalando.zally.core.ObjectTreeReader
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.ruleset.zalando.util.getResourceJson
 import io.swagger.v3.oas.models.OpenAPI
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContext
+import org.zalando.zally.core.ObjectTreeReader
+import org.zalando.zally.core.rulesConfig
+import org.zalando.zally.ruleset.zalando.util.getResourceJson
 
 class UseOpenApiRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseProblemJsonRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseProblemJsonRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.test.ZallyAssertions
-import org.zalando.zally.core.DefaultContextFactory
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.test.ZallyAssertions
 
 class UseProblemJsonRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/UseStandardHttpStatusCodesTest.kt
@@ -1,14 +1,14 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContext
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.rule.api.Context
-import org.zalando.zally.ruleset.zalando.util.openApiWithOperations
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContext
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
 import org.zalando.zally.core.util.HttpStatus
+import org.zalando.zally.rule.api.Context
+import org.zalando.zally.ruleset.zalando.util.openApiWithOperations
 
 @Suppress("UndocumentedPublicClass")
 class UseStandardHttpStatusCodesTest {

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/VersionInInfoSectionRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/VersionInInfoSectionRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
 
 class VersionInInfoSectionRuleTest {
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/util/TestUtil.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/util/TestUtil.kt
@@ -3,13 +3,13 @@ package org.zalando.zally.ruleset.zalando.util
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.zalando.zally.core.ObjectTreeReader
 import io.swagger.parser.util.ClasspathHelper
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.Paths
 import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.responses.ApiResponses
+import org.zalando.zally.core.ObjectTreeReader
 import java.io.StringReader
 
 val testConfig: Config by lazy {

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/util/WordUtilTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/util/WordUtilTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zalando.util
 
-import org.zalando.zally.ruleset.zalando.util.WordUtil.isPlural
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.zalando.zally.ruleset.zalando.util.WordUtil.isPlural
 
 class WordUtilTest {
     @Test

--- a/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/AtMostOneBodyParameterRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/AtMostOneBodyParameterRule.kt
@@ -1,11 +1,11 @@
 package org.zalando.zally.ruleset.zally
 
+import io.swagger.models.parameters.BodyParameter
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import io.swagger.models.parameters.BodyParameter
 
 @Rule(
     ruleSet = ZallyRuleSet::class,

--- a/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/NoProtocolInHostRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/NoProtocolInHostRule.kt
@@ -1,12 +1,12 @@
 package org.zalando.zally.ruleset.zally
 
+import io.swagger.models.Swagger
 import org.zalando.zally.core.toJsonPointer
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import io.swagger.models.Swagger
 
 /**
  * Validates that [Swagger.host] does not contain a url scheme as required by
@@ -29,7 +29,6 @@ class NoProtocolInHostRule {
     fun validate(context: Context): List<Violation> {
         val host = context.swagger?.host.orEmpty()
         return when {
-
             context.isOpenAPI3() -> emptyList()
 
             "://" in host -> listOf(

--- a/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/NoUnusedDefinitionsRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/NoUnusedDefinitionsRule.kt
@@ -20,7 +20,6 @@ class NoUnusedDefinitionsRule {
 
     @Check(severity = Severity.SHOULD)
     fun checkSwagger(root: JsonNode): List<Violation> {
-
         val used = used(root) { node ->
             node["discriminator"]
                 ?.asText()
@@ -45,7 +44,6 @@ class NoUnusedDefinitionsRule {
 
     @Check(severity = Severity.SHOULD)
     fun checkOpenAPI(root: JsonNode): List<Violation> {
-
         val used = used(root) { node ->
             node["discriminator"]
                 ?.get("mapping")

--- a/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/NumericPropertyBoundsRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/NumericPropertyBoundsRule.kt
@@ -1,11 +1,11 @@
 package org.zalando.zally.ruleset.zally
 
+import org.zalando.zally.core.util.getAllProperties
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import org.zalando.zally.core.util.getAllProperties
 import java.math.BigDecimal
 
 @Rule(

--- a/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/PathParameterRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/PathParameterRule.kt
@@ -57,7 +57,9 @@ class PathParameterRule {
                 .filter {
                     if (it.content != null) {
                         it.content.isEmpty() || it.content.size > 1
-                    } else false
+                    } else {
+                        false
+                    }
                 }
                 .map { parameter ->
                     context.violation(contentMapStructureErrorMessage(parameter.name), parameter)

--- a/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/StringPropertyLengthBoundsRule.kt
+++ b/server/zally-ruleset-zally/src/main/kotlin/org/zalando/zally/ruleset/zally/StringPropertyLengthBoundsRule.kt
@@ -1,13 +1,13 @@
 package org.zalando.zally.ruleset.zally
 
 import com.typesafe.config.Config
+import io.swagger.v3.oas.models.media.Schema
 import org.zalando.zally.core.util.getAllProperties
 import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import io.swagger.v3.oas.models.media.Schema
 
 @Rule(
     ruleSet = ZallyRuleSet::class,

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/AtMostOneBodyParameterRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/AtMostOneBodyParameterRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zally
 
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.test.ZallyAssertions
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.test.ZallyAssertions
 
 class AtMostOneBodyParameterRuleTest {
 

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/AvoidXZallyIgnoreRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/AvoidXZallyIgnoreRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zally
 
-import org.zalando.zally.core.ObjectTreeReader
-import org.zalando.zally.test.ZallyAssertions
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.ObjectTreeReader
+import org.zalando.zally.test.ZallyAssertions
 
 class AvoidXZallyIgnoreRuleTest {
 

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/CaseCheckerRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/CaseCheckerRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zally
 
-import org.zalando.zally.test.ZallyAssertions
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
+import org.zalando.zally.test.ZallyAssertions
 
 @Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction", "TooManyFunctions", "StringLiteralDuplication")
 class CaseCheckerRuleTest {

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/NoProtocolInHostRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/NoProtocolInHostRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zally
 
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.test.ZallyAssertions
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.test.ZallyAssertions
 
 class NoProtocolInHostRuleTest {
 

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/NoUnusedDefinitionsRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/NoUnusedDefinitionsRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zally
 
-import org.zalando.zally.test.ZallyAssertions
-import org.zalando.zally.core.ObjectTreeReader
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.ObjectTreeReader
+import org.zalando.zally.test.ZallyAssertions
 
 class NoUnusedDefinitionsRuleTest {
 
@@ -13,7 +13,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkSwagger with unreferenced definitions returns violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -34,7 +33,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkSwagger with referenced definitions returns empty`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -57,7 +55,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkSwagger with discriminator enum returns empty`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -118,7 +115,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkSwagger with unreferenced parameter returns violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -139,7 +135,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkSwagger with referenced parameter returns no violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -163,7 +158,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkSwagger with unreferenced response returns violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -184,7 +178,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkSwagger with referenced response returns no violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -210,7 +203,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkOpenAPI with unreferenced definitions returns violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -232,7 +224,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkOpenAPI with referenced definitions returns empty`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -256,7 +247,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkOpenAPI with discriminator enum returns empty`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -321,7 +311,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkOpenAPI with unreferenced parameter returns violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -345,7 +334,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkOpenAPI with referenced parameter returns no violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -372,7 +360,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkOpenAPI with unreferenced response returns violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """
@@ -394,7 +381,6 @@ class NoUnusedDefinitionsRuleTest {
 
     @Test
     fun `checkOpenAPI with referenced response returns no violations`() {
-
         @Language("YAML")
         val root = reader.read(
             """

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/NumericPropertyBoundsRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/NumericPropertyBoundsRuleTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.ruleset.zally
 
-import org.zalando.zally.test.ZallyAssertions
-import org.zalando.zally.core.DefaultContextFactory
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.test.ZallyAssertions
 
 class NumericPropertyBoundsRuleTest {
 

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/PathParameterRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/PathParameterRuleTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.ruleset.zally
 
 import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.zalando.zally.core.DefaultContextFactory
 import org.zalando.zally.test.ZallyAssertions.assertThat
-import org.junit.jupiter.api.Disabled
 
 class PathParameterRuleTest {
 

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/StringPropertyLengthBoundsRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/StringPropertyLengthBoundsRuleTest.kt
@@ -1,11 +1,11 @@
 package org.zalando.zally.ruleset.zally
 
-import org.zalando.zally.test.ZallyAssertions
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.DefaultContextFactory
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
+import org.zalando.zally.test.ZallyAssertions
 
 class StringPropertyLengthBoundsRuleTest {
 

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/TagAllOperationsRuleTest.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/TagAllOperationsRuleTest.kt
@@ -1,11 +1,11 @@
 package org.zalando.zally.ruleset.zally
 
-import org.zalando.zally.test.ZallyAssertions
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
 import org.zalando.zally.core.DefaultContextFactory
 import org.zalando.zally.rule.api.Context
 import org.zalando.zally.rule.api.Violation
-import org.intellij.lang.annotations.Language
-import org.junit.jupiter.api.Test
+import org.zalando.zally.test.ZallyAssertions
 
 class TagAllOperationsRuleTest {
 

--- a/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/util/TestUtil.kt
+++ b/server/zally-ruleset-zally/src/test/kotlin/org/zalando/zally/ruleset/zally/util/TestUtil.kt
@@ -3,13 +3,13 @@ package org.zalando.zally.ruleset.zally.util
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.zalando.zally.core.ObjectTreeReader
 import io.swagger.parser.util.ClasspathHelper
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.Paths
 import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.responses.ApiResponses
+import org.zalando.zally.core.ObjectTreeReader
 import java.io.StringReader
 
 val testConfig: Config by lazy {

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/apireview/ApiDefinitionReader.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/apireview/ApiDefinitionReader.kt
@@ -1,8 +1,5 @@
 package org.zalando.zally.apireview
 
-import org.zalando.zally.dto.ApiDefinitionRequest
-import org.zalando.zally.exception.InaccessibleResourceUrlException
-import org.zalando.zally.exception.MissingApiDefinitionException
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -13,6 +10,9 @@ import org.springframework.stereotype.Component
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestTemplate
+import org.zalando.zally.dto.ApiDefinitionRequest
+import org.zalando.zally.exception.InaccessibleResourceUrlException
+import org.zalando.zally.exception.MissingApiDefinitionException
 
 @Component
 class ApiDefinitionReader(private val client: RestTemplate) {

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/apireview/ApiReviewRepository.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/apireview/ApiReviewRepository.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.apireview
 
-import org.zalando.zally.statistic.ReviewStatistics
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.query.Param
+import org.zalando.zally.statistic.ReviewStatistics
 import java.time.LocalDate
 import java.util.UUID
 

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/apireview/ApiViolationsController.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/apireview/ApiViolationsController.kt
@@ -1,14 +1,5 @@
 package org.zalando.zally.apireview
 
-import org.zalando.zally.dto.ApiDefinitionRequest
-import org.zalando.zally.dto.ApiDefinitionResponse
-import org.zalando.zally.dto.ViolationDTO
-import org.zalando.zally.exception.ApiReviewNotFoundException
-import org.zalando.zally.exception.InaccessibleResourceUrlException
-import org.zalando.zally.exception.MissingApiDefinitionException
-import org.zalando.zally.core.ApiValidator
-import org.zalando.zally.core.RulesPolicy
-import org.zalando.zally.rule.api.Severity
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CrossOrigin
@@ -20,6 +11,15 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
+import org.zalando.zally.core.ApiValidator
+import org.zalando.zally.core.RulesPolicy
+import org.zalando.zally.dto.ApiDefinitionRequest
+import org.zalando.zally.dto.ApiDefinitionResponse
+import org.zalando.zally.dto.ViolationDTO
+import org.zalando.zally.exception.ApiReviewNotFoundException
+import org.zalando.zally.exception.InaccessibleResourceUrlException
+import org.zalando.zally.exception.MissingApiDefinitionException
+import org.zalando.zally.rule.api.Severity
 import java.util.UUID
 
 @CrossOrigin

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/apireview/RuleViolation.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/apireview/RuleViolation.kt
@@ -15,7 +15,10 @@ import javax.persistence.ManyToOne
 
 @Entity
 class RuleViolation(
-    @Suppress("unused") @JsonIgnore @ManyToOne(optional = false) val apiReview: ApiReview,
+    @Suppress("unused")
+    @JsonIgnore
+    @ManyToOne(optional = false)
+    val apiReview: ApiReview,
     result: Result
 ) : Serializable {
 

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/ContextFactoryConfiguration.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/ContextFactoryConfiguration.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.configuration
 
-import org.zalando.zally.core.DefaultContextFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.zalando.zally.core.DefaultContextFactory
 import java.util.regex.Pattern
 
 @Configuration

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/RulesDefinitionConfiguration.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/RulesDefinitionConfiguration.kt
@@ -1,6 +1,5 @@
 package org.zalando.zally.configuration
 
-import org.zalando.zally.rule.api.Rule
 import org.springframework.beans.BeansException
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.beans.factory.support.BeanDefinitionRegistry
@@ -10,6 +9,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.zalando.zally.rule.api.Rule
 
 /**
  * Register classes annotated with [Rule] as BeanDefinition prior to any Bean instantiation.

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/RulesManagerConfiguration.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/RulesManagerConfiguration.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.configuration
 
 import com.typesafe.config.Config
-import org.zalando.zally.core.RulesManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.zalando.zally.core.RulesManager
 
 @Configuration
 class RulesManagerConfiguration {

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/RulesPolicyConfiguration.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/RulesPolicyConfiguration.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.configuration
 
-import org.zalando.zally.core.RulesPolicy
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.zalando.zally.core.RulesPolicy
 
 @Configuration
 class RulesPolicyConfiguration {

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/RulesValidatorConfiguration.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/configuration/RulesValidatorConfiguration.kt
@@ -1,15 +1,15 @@
 package org.zalando.zally.configuration
 
-import org.zalando.zally.core.DefaultContextFactory
-import org.zalando.zally.core.ApiValidator
-import org.zalando.zally.core.CompositeRulesValidator
-import org.zalando.zally.core.ContextRulesValidator
-import org.zalando.zally.core.JsonRulesValidator
-import org.zalando.zally.core.RulesManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import org.zalando.zally.core.ApiValidator
+import org.zalando.zally.core.CompositeRulesValidator
+import org.zalando.zally.core.ContextRulesValidator
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.JsonRulesValidator
+import org.zalando.zally.core.RulesManager
 
 @Configuration
 class RulesValidatorConfiguration {

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/dto/SeverityBinder.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/dto/SeverityBinder.kt
@@ -1,8 +1,7 @@
 package org.zalando.zally.dto
 
-import org.zalando.zally.rule.api.Severity
 import org.springframework.util.StringUtils
-
+import org.zalando.zally.rule.api.Severity
 import java.beans.PropertyEditorSupport
 
 class SeverityBinder : PropertyEditorSupport() {

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/dto/ViolationDTO.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/dto/ViolationDTO.kt
@@ -9,7 +9,9 @@ data class ViolationDTO(
     val description: String? = null,
     val violationType: Severity? = null,
     val ruleLink: String? = null,
-    @JsonInclude(Include.NON_NULL) @Deprecated("Use `pointer` instead.") val paths: List<String> = emptyList(),
+    @JsonInclude(Include.NON_NULL)
+    @Deprecated("Use `pointer` instead.")
+    val paths: List<String> = emptyList(),
     @JsonInclude(Include.NON_NULL) val pointer: String? = null,
     val startLine: Int? = null,
     val endLine: Int? = null

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/rule/SupportedRulesController.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/rule/SupportedRulesController.kt
@@ -1,12 +1,5 @@
 package org.zalando.zally.rule
 
-import org.zalando.zally.core.RuleDetails
-import org.zalando.zally.core.RulesManager
-import org.zalando.zally.core.RulesPolicy
-import org.zalando.zally.dto.RuleDTO
-import org.zalando.zally.dto.RulesListDTO
-import org.zalando.zally.dto.SeverityBinder
-import org.zalando.zally.rule.api.Severity
 import org.springframework.web.bind.WebDataBinder
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,6 +7,13 @@ import org.springframework.web.bind.annotation.InitBinder
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
+import org.zalando.zally.core.RuleDetails
+import org.zalando.zally.core.RulesManager
+import org.zalando.zally.core.RulesPolicy
+import org.zalando.zally.dto.RuleDTO
+import org.zalando.zally.dto.RulesListDTO
+import org.zalando.zally.dto.SeverityBinder
+import org.zalando.zally.rule.api.Severity
 
 /**
  * REST API for listing the rules supported by this server.
@@ -43,7 +43,6 @@ class SupportedRulesController(private val rules: RulesManager, private val rule
         @RequestParam(value = "type", required = false) typeFilter: Severity?,
         @RequestParam(value = "is_active", required = false) isActiveFilter: Boolean?
     ): RulesListDTO {
-
         val filteredRules = rules
             .rules
             .filter { filterByIsActive(it, isActiveFilter) }

--- a/server/zally-server/src/main/kotlin/org/zalando/zally/statistic/ReviewStatisticsController.kt
+++ b/server/zally-server/src/main/kotlin/org/zalando/zally/statistic/ReviewStatisticsController.kt
@@ -1,8 +1,5 @@
 package org.zalando.zally.statistic
 
-import org.zalando.zally.apireview.ApiReviewRepository
-import org.zalando.zally.exception.InsufficientTimeIntervalParameterException
-import org.zalando.zally.exception.TimeParameterIsInTheFutureException
 import org.slf4j.LoggerFactory
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.CrossOrigin
@@ -10,6 +7,9 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
+import org.zalando.zally.apireview.ApiReviewRepository
+import org.zalando.zally.exception.InsufficientTimeIntervalParameterException
+import org.zalando.zally.exception.TimeParameterIsInTheFutureException
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -21,11 +21,14 @@ class ReviewStatisticsController(private val apiReviewRepository: ApiReviewRepos
     @ResponseBody
     @GetMapping("/review-statistics")
     fun retrieveReviewStatistics(
-        @RequestParam(value = "from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate?,
-        @RequestParam(value = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?,
+        @RequestParam(value = "from", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        from: LocalDate?,
+        @RequestParam(value = "to", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        to: LocalDate?,
         @RequestParam(value = "user_agent", required = false) userAgent: String?
     ): ReviewStatistics {
-
         if (from != null && from.isAfter(today())) {
             throw TimeParameterIsInTheFutureException()
         }

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/ApiDefinitionReaderTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/ApiDefinitionReaderTest.kt
@@ -1,9 +1,5 @@
 package org.zalando.zally.apireview
 
-import org.zalando.zally.dto.ApiDefinitionRequest
-import org.zalando.zally.exception.InaccessibleResourceUrlException
-import org.zalando.zally.exception.MissingApiDefinitionException
-import org.zalando.zally.util.JadlerUtil
 import net.jadler.Jadler.closeJadler
 import net.jadler.Jadler.initJadlerUsing
 import net.jadler.stubbing.server.jdk.JdkStubHttpServer
@@ -16,6 +12,10 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.MediaType.TEXT_HTML_VALUE
 import org.springframework.web.client.RestTemplate
+import org.zalando.zally.dto.ApiDefinitionRequest
+import org.zalando.zally.exception.InaccessibleResourceUrlException
+import org.zalando.zally.exception.MissingApiDefinitionException
+import org.zalando.zally.util.JadlerUtil
 
 class ApiDefinitionReaderTest {
 

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/ApiReviewTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/ApiReviewTest.kt
@@ -1,13 +1,13 @@
 package org.zalando.zally.apireview
 
 import com.fasterxml.jackson.core.JsonPointer
-import org.zalando.zally.core.toJsonPointer
-import org.zalando.zally.dto.ApiDefinitionRequest
-import org.zalando.zally.core.Result
-import org.zalando.zally.rule.api.Severity
-import org.zalando.zally.util.resourceToString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.zalando.zally.core.Result
+import org.zalando.zally.core.toJsonPointer
+import org.zalando.zally.dto.ApiDefinitionRequest
+import org.zalando.zally.rule.api.Severity
+import org.zalando.zally.util.resourceToString
 import java.io.IOException
 import java.net.URI
 import java.util.Arrays.asList

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/ApiViolationsControllerTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/ApiViolationsControllerTest.kt
@@ -1,9 +1,5 @@
 package org.zalando.zally.apireview
 
-import org.zalando.zally.apireview.RestApiTestConfiguration.Companion.assertRuleManagerUsingAllAnnotatedRules
-import org.zalando.zally.configuration.JacksonObjectMapperConfiguration
-import org.zalando.zally.core.RulesManager
-import org.zalando.zally.dto.ApiDefinitionRequest
 import org.hamcrest.CoreMatchers.hasItem
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.notNullValue
@@ -21,6 +17,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.zalando.zally.apireview.RestApiTestConfiguration.Companion.assertRuleManagerUsingAllAnnotatedRules
+import org.zalando.zally.configuration.JacksonObjectMapperConfiguration
+import org.zalando.zally.core.RulesManager
+import org.zalando.zally.dto.ApiDefinitionRequest
 
 @SpringBootTest
 @ActiveProfiles("test", "all-annotated-rules")
@@ -66,7 +66,6 @@ class ApiViolationsControllerTest {
 
     @Test
     fun `getExistingViolationResponse with existing responds Ok`() {
-
         val location = mvc.perform(
             post("/api-violations")
                 .contentType("application/json")

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiBaseTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiBaseTest.kt
@@ -1,13 +1,5 @@
 package org.zalando.zally.apireview
 
-import org.zalando.zally.Application
-import org.zalando.zally.apireview.RestApiTestConfiguration.Companion.assertRuleManagerUsingLimitedRules
-import org.zalando.zally.core.RulesManager
-import org.zalando.zally.dto.ApiDefinitionRequest
-import org.zalando.zally.dto.ApiDefinitionResponse
-import org.zalando.zally.dto.RuleDTO
-import org.zalando.zally.dto.RulesListDTO
-import org.zalando.zally.statistic.ReviewStatistics
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,6 +10,14 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.util.UriComponentsBuilder.fromPath
+import org.zalando.zally.Application
+import org.zalando.zally.apireview.RestApiTestConfiguration.Companion.assertRuleManagerUsingLimitedRules
+import org.zalando.zally.core.RulesManager
+import org.zalando.zally.dto.ApiDefinitionRequest
+import org.zalando.zally.dto.ApiDefinitionResponse
+import org.zalando.zally.dto.RuleDTO
+import org.zalando.zally.dto.RulesListDTO
+import org.zalando.zally.statistic.ReviewStatistics
 import java.time.LocalDate
 
 @SpringBootTest(

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiIgnoreRulesTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiIgnoreRulesTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.apireview
 
-import org.zalando.zally.util.readApiDefinition
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.TestPropertySource
+import org.zalando.zally.util.readApiDefinition
 import java.io.IOException
 
 @TestPropertySource(properties = ["zally.ignoreRules=TestCheckAlwaysReport3MustViolations"])

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiTestConfiguration.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiTestConfiguration.kt
@@ -2,6 +2,13 @@ package org.zalando.zally.apireview
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.config.Config
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
 import org.zalando.zally.core.AbstractRuleSet
 import org.zalando.zally.core.EMPTY_JSON_POINTER
 import org.zalando.zally.core.RulesManager
@@ -10,13 +17,6 @@ import org.zalando.zally.rule.api.Check
 import org.zalando.zally.rule.api.Rule
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Violation
-import org.assertj.core.api.Assertions.assertThat
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.ApplicationContext
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Primary
-import org.springframework.context.annotation.Profile
 
 @Configuration
 class RestApiTestConfiguration {
@@ -78,7 +78,9 @@ class RestApiTestConfiguration {
         fun validate(json: JsonNode): Violation? {
             return if ("3.0.0" != json.path("openapi").textValue()) {
                 Violation("TestCheckIsOpenApi3", "/openapi".toJsonPointer())
-            } else null
+            } else {
+                null
+            }
         }
     }
 

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiViolationsTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/apireview/RestApiViolationsTest.kt
@@ -1,13 +1,6 @@
 package org.zalando.zally.apireview
 
 import com.google.common.collect.ImmutableMap
-import org.zalando.zally.configuration.WebMvcConfiguration
-import org.zalando.zally.dto.ApiDefinitionRequest
-import org.zalando.zally.exception.MissingApiDefinitionException
-import org.zalando.zally.util.ErrorResponse
-import org.zalando.zally.util.JadlerUtil
-import org.zalando.zally.util.readApiDefinition
-import org.zalando.zally.util.resourceToString
 import net.jadler.Jadler.closeJadler
 import net.jadler.Jadler.initJadlerUsing
 import net.jadler.stubbing.server.jdk.JdkStubHttpServer
@@ -22,6 +15,13 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
+import org.zalando.zally.configuration.WebMvcConfiguration
+import org.zalando.zally.dto.ApiDefinitionRequest
+import org.zalando.zally.exception.MissingApiDefinitionException
+import org.zalando.zally.util.ErrorResponse
+import org.zalando.zally.util.JadlerUtil
+import org.zalando.zally.util.readApiDefinition
+import org.zalando.zally.util.resourceToString
 import java.io.IOException
 
 class RestApiViolationsTest : RestApiBaseTest() {
@@ -104,7 +104,9 @@ class RestApiViolationsTest : RestApiBaseTest() {
     @Throws(IOException::class)
     fun shouldRespondWithBadRequestWhenApiDefinitionFieldIsMissing() {
         val responseEntity = restTemplate.postForEntity(
-            RestApiBaseTest.API_VIOLATIONS_URL, ImmutableMap.of("my_api", "dummy"), ErrorResponse::class.java
+            RestApiBaseTest.API_VIOLATIONS_URL,
+            ImmutableMap.of("my_api", "dummy"),
+            ErrorResponse::class.java
         )
 
         assertThat(responseEntity.statusCode).isEqualTo(BAD_REQUEST)
@@ -161,7 +163,9 @@ class RestApiViolationsTest : RestApiBaseTest() {
     fun shouldReturn404WhenHostNotRecognised() {
         val request = ApiDefinitionRequest.fromUrl("http://remote-localhost/test.yaml")
         val responseEntity = restTemplate.postForEntity(
-            RestApiBaseTest.API_VIOLATIONS_URL, request, ErrorResponse::class.java
+            RestApiBaseTest.API_VIOLATIONS_URL,
+            request,
+            ErrorResponse::class.java
         )
 
         assertThat(responseEntity.statusCode).isEqualTo(NOT_FOUND)

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/dto/SeverityBinderTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/dto/SeverityBinderTest.kt
@@ -1,9 +1,9 @@
 package org.zalando.zally.dto
 
-import org.zalando.zally.rule.api.Severity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.zalando.zally.rule.api.Severity
 
 class SeverityBinderTest {
     @Test

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/dto/ViolationsCounterTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/dto/ViolationsCounterTest.kt
@@ -1,14 +1,14 @@
 package org.zalando.zally.dto
 
-import org.zalando.zally.core.toJsonPointer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import org.zalando.zally.core.Result
+import org.zalando.zally.core.toJsonPointer
 import org.zalando.zally.rule.api.Severity
 import org.zalando.zally.rule.api.Severity.HINT
 import org.zalando.zally.rule.api.Severity.MAY
 import org.zalando.zally.rule.api.Severity.MUST
 import org.zalando.zally.rule.api.Severity.SHOULD
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import java.net.URI
 
 class ViolationsCounterTest {

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/exception/InaccessibleResourceUrlExceptionTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/exception/InaccessibleResourceUrlExceptionTest.kt
@@ -8,7 +8,8 @@ class InaccessibleResourceUrlExceptionTest {
     @Test
     fun shouldReturnParametersSpecifiedInConstructor() {
         val exception = InaccessibleResourceUrlException(
-            "Test Message", HttpStatus.BAD_REQUEST
+            "Test Message",
+            HttpStatus.BAD_REQUEST
         )
 
         assertEquals("Test Message", exception.message)

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/rule/CaseCheckerParameterizedTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/rule/CaseCheckerParameterizedTest.kt
@@ -1,10 +1,10 @@
 package org.zalando.zally.rule
 
-import org.zalando.zally.core.rulesConfig
-import org.zalando.zally.core.CaseChecker
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.zalando.zally.core.CaseChecker
+import org.zalando.zally.core.rulesConfig
 
 class CaseCheckerParameterizedTest() {
 

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/rule/NullPointerExceptionTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/rule/NullPointerExceptionTest.kt
@@ -4,14 +4,6 @@ import com.fasterxml.jackson.core.JsonPointer
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.zalando.zally.apireview.RestApiTestConfiguration.Companion.assertRuleManagerUsingAllAnnotatedRules
-import org.zalando.zally.core.CompositeRulesValidator
-import org.zalando.zally.core.EMPTY_JSON_POINTER
-import org.zalando.zally.core.ObjectTreeReader
-import org.zalando.zally.core.RulesManager
-import org.zalando.zally.core.RulesPolicy
-import org.zalando.zally.core.plus
-import org.zalando.zally.core.toEscapedJsonPointer
 import io.swagger.util.Yaml
 import org.intellij.lang.annotations.Language
 import org.junit.ClassRule
@@ -23,6 +15,14 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.rules.SpringClassRule
 import org.springframework.test.context.junit4.rules.SpringMethodRule
+import org.zalando.zally.apireview.RestApiTestConfiguration.Companion.assertRuleManagerUsingAllAnnotatedRules
+import org.zalando.zally.core.CompositeRulesValidator
+import org.zalando.zally.core.EMPTY_JSON_POINTER
+import org.zalando.zally.core.ObjectTreeReader
+import org.zalando.zally.core.RulesManager
+import org.zalando.zally.core.RulesPolicy
+import org.zalando.zally.core.plus
+import org.zalando.zally.core.toEscapedJsonPointer
 
 @SpringBootTest
 @ActiveProfiles("test", "all-annotated-rules")

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/rule/RestSupportedRulesTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/rule/RestSupportedRulesTest.kt
@@ -1,14 +1,14 @@
 package org.zalando.zally.rule
 
-import org.zalando.zally.apireview.RestApiBaseTest
-import org.zalando.zally.core.RulesManager
-import org.zalando.zally.util.ErrorResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.test.context.TestPropertySource
+import org.zalando.zally.apireview.RestApiBaseTest
+import org.zalando.zally.core.RulesManager
+import org.zalando.zally.util.ErrorResponse
 
 @Suppress("UndocumentedPublicClass")
 @TestPropertySource(properties = ["zally.ignoreRules=TestCheckAlwaysReport3MustViolations"])
@@ -57,7 +57,6 @@ class RestSupportedRulesTest : RestApiBaseTest() {
 
     @Test
     fun testFilterByType() {
-
         var count = 0
         count += getSupportedRules("MuST", null).size
         count += getSupportedRules("ShOuLd", null).size

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/rule/RuleUniquenessTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/rule/RuleUniquenessTest.kt
@@ -1,12 +1,12 @@
 package org.zalando.zally.rule
 
-import org.zalando.zally.apireview.RestApiTestConfiguration.Companion.assertRuleManagerUsingAllAnnotatedRules
-import org.zalando.zally.core.RulesManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import org.zalando.zally.apireview.RestApiTestConfiguration.Companion.assertRuleManagerUsingAllAnnotatedRules
+import org.zalando.zally.core.RulesManager
 
 @SpringBootTest
 @ActiveProfiles("test", "all-annotated-rules")

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/statistic/RestReviewStatisticsTest.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/statistic/RestReviewStatisticsTest.kt
@@ -1,16 +1,16 @@
 package org.zalando.zally.statistic
 
-import org.zalando.zally.apireview.ApiReview
-import org.zalando.zally.apireview.RestApiBaseTest
-import org.zalando.zally.core.toJsonPointer
-import org.zalando.zally.dto.ApiDefinitionRequest
-import org.zalando.zally.core.Result
-import org.zalando.zally.rule.api.Severity
-import org.zalando.zally.util.ErrorResponse
-import org.zalando.zally.util.TestDateUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.zalando.zally.apireview.ApiReview
+import org.zalando.zally.apireview.RestApiBaseTest
+import org.zalando.zally.core.Result
+import org.zalando.zally.core.toJsonPointer
+import org.zalando.zally.dto.ApiDefinitionRequest
+import org.zalando.zally.rule.api.Severity
+import org.zalando.zally.util.ErrorResponse
+import org.zalando.zally.util.TestDateUtil
 import java.net.URI
 import java.time.LocalDate
 

--- a/server/zally-server/src/test/kotlin/org/zalando/zally/util/ResourceUtil.kt
+++ b/server/zally-server/src/test/kotlin/org/zalando/zally/util/ResourceUtil.kt
@@ -1,7 +1,7 @@
 package org.zalando.zally.util
 
-import org.zalando.zally.dto.ApiDefinitionRequest
 import org.apache.commons.io.IOUtils
+import org.zalando.zally.dto.ApiDefinitionRequest
 import java.nio.charset.Charset
 
 fun resourceToString(resourceName: String): String {

--- a/server/zally-test/src/main/kotlin/org/zalando/zally/test/ViolationAssert.kt
+++ b/server/zally-test/src/main/kotlin/org/zalando/zally/test/ViolationAssert.kt
@@ -1,8 +1,8 @@
 package org.zalando.zally.test
 
-import org.zalando.zally.rule.api.Violation
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.StringAssert
+import org.zalando.zally.rule.api.Violation
 
 @Suppress("UndocumentedPublicClass")
 class ViolationAssert(actual: Violation?) :


### PR DESCRIPTION
This pull request activates and applies the new linter rules using the automated code formatting it provides. In addition, it fixes the docker image build that was broken in #1433 when migrating to Java 17.