### PR TITLE
chore(deps): bump swagger-parser from 2.1.12 to 2.1.26

### DIFF
--- a/server/zally-core/build.gradle.kts
+++ b/server/zally-core/build.gradle.kts
@@ -2,9 +2,12 @@ dependencies {
     kapt("com.google.auto.service:auto-service:1.0.1")
 
     api(project(":zally-rule-api"))
-    api("io.swagger.parser.v3:swagger-parser:2.1.12")
+    api("io.swagger.parser.v3:swagger-parser:2.1.26")
     api("io.github.config4k:config4k:0.5.0")
     implementation("com.google.auto.service:auto-service:1.0.1")
+
+    implementation("javax.mail:javax.mail-api:1.6.2")
+    runtimeOnly("com.sun.mail:javax.mail:1.6.2")
 
     testImplementation(project(":zally-test"))
     testImplementation("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
This PR is bumping `io.swagger.parser.v3:swagger-parser` from `2.1.12` (Feb 15, 2023) to `2.1.26` (Mar 25, 2025)

After the update some tests started failing, example:

```
ReverseAstTest > OpenAPI extension JsonPointers are parsed correctly() FAILED
    org.opentest4j.AssertionFailedError:
    expected: /info/x-test-extension
     but was: /info//x-test-extension
        at java.base@17.0.15/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base@17.0.15/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base@17.0.15/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base@17.0.15/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at app//org.zalando.zally.core.ast.ReverseAstTest.OpenAPI extension JsonPointers are parsed correctly(ReverseAstTest.kt:240) 
```

so I had to make an adjust in `handleObject` to ensure that the extension map itself wont add an empty path.

after that, there were some issues with java-mail, example:
```
JsonSchemaValidatorTest > invalid schemas result in empty violation pointers() FAILED
    java.lang.NoClassDefFoundError: javax/mail/internet/AddressException
        at com.github.fge.jsonschema.library.format.CommonFormatAttributesDictionary.<clinit>(CommonFormatAttributesDictionary.java:56)
        at com.github.fge.jsonschema.library.format.DraftV3FormatAttributesDictionary.<clinit>(DraftV3FormatAttributesDictionary.java:47)
        at com.github.fge.jsonschema.library.DraftV3Library.<clinit>(DraftV3Library.java:36)
        at com.github.fge.jsonschema.cfg.ValidationConfigurationBuilder.<clinit>(ValidationConfigurationBuilder.java:63)
        at com.github.fge.jsonschema.cfg.ValidationConfiguration.newBuilder(ValidationConfiguration.java:97)
        at org.zalando.zally.core.JsonSchemaValidator.createValidatorFactory(JsonSchemaValidator.kt:83)
        at org.zalando.zally.core.JsonSchemaValidator.<init>(JsonSchemaValidator.kt:29)
        at org.zalando.zally.core.JsonSchemaValidator.<init>(JsonSchemaValidator.kt:18)
        at org.zalando.zally.core.JsonSchemaValidatorTest.invalid schemas result in empty violation pointers(JsonSchemaValidatorTest.kt:64)

        Caused by:
        java.lang.ClassNotFoundException: javax.mail.internet.AddressException
            at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
            at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
            at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
            ... 9 more 
 ```
 
 making the dependency explicit fixed those, build s green ✅ 
 