### PR TITLE
feat: adjust date time property conventions rule (#1536)

### DIFF
--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRule.kt
@@ -13,7 +13,7 @@ import org.zalando.zally.rule.api.Violation
     ruleSet = ZalandoRuleSet::class,
     id = "235",
     severity = Severity.SHOULD,
-    title = "Name date/time properties using the common suffix"
+    title = "Name date/time properties using the common conventions"
 )
 class DateTimePropertiesSuffixRule(rulesConfig: Config) {
 

--- a/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRule.kt
+++ b/server/zally-ruleset-zalando/src/main/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRule.kt
@@ -13,7 +13,7 @@ import org.zalando.zally.rule.api.Violation
     ruleSet = ZalandoRuleSet::class,
     id = "235",
     severity = Severity.SHOULD,
-    title = "Name date/time properties using the \"_at\" suffix"
+    title = "Name date/time properties using the common suffix"
 )
 class DateTimePropertiesSuffixRule(rulesConfig: Config) {
 
@@ -22,7 +22,7 @@ class DateTimePropertiesSuffixRule(rulesConfig: Config) {
         .map { Regex(it) }
         .toSet()
 
-    private val propertyFormats = setOf("date", "date-time")
+    private val propertyFormats = setOf("date", "time", "date-time")
 
     @Check(severity = Severity.SHOULD)
     fun validate(context: Context): List<Violation> {

--- a/server/zally-ruleset-zalando/src/main/resources/reference.conf
+++ b/server/zally-ruleset-zalando/src/main/resources/reference.conf
@@ -216,7 +216,10 @@ ProprietaryHeadersRule {
 
 DateTimePropertiesSuffixRule {
   patterns: [
-    ".*_at"
+    ".+_at",
+    "(.+_)*time(stamp)?(_.+)?",
+    "(.+_)*date(_.+)*",
+    "(.+_)*day(_.+)*"
   ]
 }
 

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/DateTimePropertiesSuffixRuleTest.kt
@@ -107,7 +107,7 @@ class DateTimePropertiesSuffixRuleTest {
     }
 
     @Test
-    fun `should fail on prefix _at and succeed on prefix patterns`() {
+    fun `should fail on prefix at_ and succeed on prefix patterns`() {
         @Language("YAML")
         val content = """
             openapi: '3.0.1'


### PR DESCRIPTION
This pull request adjusts the date time property suffix rule according to the rule change conducted in https://github.com/zalando/restful-api-guidelines/pull/811.

fixes #1501.