### PR TITLE
Enable 'types' compatibility

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -15,4 +15,4 @@ COPY --from=builder /var/app/zally-server/build/libs/zally-server.jar /
 
 EXPOSE 8080
 
-CMD java -jar /zally-server.jar
+CMD java -Dbind-type=true -jar /zally-server.jar

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -49,7 +49,7 @@ subprojects {
         includeCompileClasspath = false
     }
 
-    tasks.withType<KotlinCompile>().configureEach() {
+    tasks.withType<KotlinCompile>().configureEach {
         kotlinOptions.jvmTarget = "17"
     }
 
@@ -186,6 +186,7 @@ subprojects {
     tasks.test {
         useJUnitPlatform()
         finalizedBy(tasks.jacocoTestReport)
+        systemProperty("bind-type", "true")
     }
 
     tasks.jacocoTestReport {

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/CommonFieldTypesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/CommonFieldTypesRuleTest.kt
@@ -121,7 +121,7 @@ class CommonFieldTypesRuleTest {
                       properties:
                         id:
                           type: string
-                """.trimIndent(),
+                """.trimIndent()
             )
 
         assertThat(rule.checkTypesOfCommonFields(context)).isEmpty()

--- a/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/CommonFieldTypesRuleTest.kt
+++ b/server/zally-ruleset-zalando/src/test/kotlin/org/zalando/zally/ruleset/zalando/CommonFieldTypesRuleTest.kt
@@ -109,6 +109,25 @@ class CommonFieldTypesRuleTest {
     }
 
     @Test
+    fun `checkTypesOfCommonFields should not return any violations for openapi version with 'type' as array`() {
+        @Language("YAML")
+        val context =
+            DefaultContextFactory().getOpenApiContext(
+                """
+                openapi: 3.1.0
+                components:
+                  schemas:
+                    Pet:
+                      properties:
+                        id:
+                          type: string
+                """.trimIndent(),
+            )
+
+        assertThat(rule.checkTypesOfCommonFields(context)).isEmpty()
+    }
+
+    @Test
     fun `checkTypesOfCommonFields should return a violation for a specification with invalid common field in a schema`() {
         @Language("YAML")
         val context = DefaultContextFactory().getOpenApiContext(
@@ -262,7 +281,7 @@ class CommonFieldTypesRuleTest {
                 CustomId:
                   type: object
                   properties:
-                    id: 
+                    id:
                       type: integer
                       format: int64
             """.trimIndent()

--- a/server/zally-server/build.gradle.kts
+++ b/server/zally-server/build.gradle.kts
@@ -47,6 +47,10 @@ dependencies {
     testImplementation("org.mockito:mockito-core:4.11.0")
 }
 
+tasks.withType<JavaExec> {
+    systemProperty("bind-type", "true")
+}
+
 tasks.bootRun {
     jvmArgs = listOf("-Dspring.profiles.active=dev")
 }


### PR DESCRIPTION
Fixes #1544

### Changes
- set `bind-type` environment variable to `true` to support `schema.type` compatibility with new `schema.types` property.

> let me know if there is a better way to setup environment variable in a single place for the project

### Context

In new openapi specification versions schema property `type` is supporting multiple values. Internally, new list property `types` is used in the java library to support such case. For all type definitions under the new specification, property `type` is `null` with `types` storing the provided values. 
To support retrieving a first value of `types` with `type` getter, system environment `bind-type` is used. This allows to treat type definitions under the new specification in the same way as before (supports only a single value). 

### Remarks

The change is fully compatible with previous specification versions. 

Library code reference:
```java
public class Schema<T> {

    public static final String BIND_TYPE_AND_TYPES = "bind-type";
    
    @OpenAPI30
    private String type = null;
    /**
     * @since 2.2.0 (OpenAPI 3.1.0)
     */
    @OpenAPI31
    private Set<String> types;
    
    public String getType() {
        boolean bindTypes = Boolean.valueOf(System.getProperty(BIND_TYPE_AND_TYPES, "false"));
        if (bindTypes && type == null && types != null && types.size() == 1) {
            return types.iterator().next();
        }
        return type;
    }
}
```